### PR TITLE
Ungalaxyification

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ variable | type | description
 `cvmfs_repositories` | list of dicts | CVMFS repository configurations, the value of `CVMFS_REPOSITORIES` in `/etc/cvmfs/default.local` plus additional settings in `/etc/cvmfs/repositories.d/<repository>/{client,server}.conf`.
 `cvmfs_quota_limit` | integer in MB | Size of CVMFS client cache. Default is `4000`.
 `cvmfs_upgrade_client` | boolean | Upgrade CVMFS on clients to the latest version if it is already installed. Default is `false`.
+`cvmfs_preload_install` | boolean | Install the `cvmfs_preload` script for [preloading the CVMFS cache][preload].
+`cvmfs_preload_path` | path | Directory where `cvmfs_preload` should be installed
 `cvmfs_install_setuid_cvmfs_wipecache` | boolean | Install a setuid binary on clients that allows unprivileged users to perform `cvmfs_config wipecache`. EL only (source is provided).
 `cvmfs_install_setuid_cvmfs_remount_sync` | boolean | Install a setuid binary on clients that allows unprivileged users to perform `cvmfs_talk remount sync`. EL only (source is provided).
 
@@ -85,6 +87,7 @@ Additionally, setting the boolean `galaxy_cvmfs_repos_enabled` to `true` will au
 and `cvmfs_repositories` by prepending `galaxy_` to the variable names. See the [defaults][defaults] for details.
 
 [defaults]: https://github.com/galaxyproject/ansible-cvmfs/blob/master/defaults/main.yml
+[preload]: http://cvmfs.readthedocs.io/en/stable/cpt-hpc.html
 
 Dependencies
 ------------

--- a/README.md
+++ b/README.md
@@ -1,17 +1,10 @@
 CVMFS
 =====
 
-Install and configure [CernVM-FS (CVMFS)][cvmfs].
-
-**NOTE: This role is not for general use. Currently, it makes certain assumptions and will, by default, configure
-[Galaxy][galaxy]'s CVMFS servers. When this role is generalized in the future it will be uploaded to [Ansible
-Galaxy][ansible-galaxy].**
-
-Also, this role is currently only works with Enterprise Linux.
+Install and configure [CernVM-FS (CVMFS)][cvmfs], particularly for [Galaxy][galaxy] servers.
 
 [cvmfs]: https://cernvm.cern.ch/portal/filesystem
 [galaxy]: https://galaxyproject.org
-[ansible-galaxy]: https://galaxy.ansible.com
 
 Requirements
 ------------
@@ -26,7 +19,72 @@ do this for you.
 Role Variables
 --------------
 
-TODO
+All variables are optional. However, if unset, the role will essentially do nothing. See the [defaults][defaults] and
+[example playbook](#example-playbook) for examples.
+
+## Client or shared client/server variables
+
+variable | type | description
+`cvmfs_role` | string | Type of CVMFS host: `client`, `stratum0`, `stratum1`, or `localproxy`. Alternatively, you may put hosts in to groups `cvmfsclients`, `cvmfsstratum0servers`, `cvmfsstratum1servers`, and `cvmfslocalproxies`. Controls what packages are installed and what configuration is performed.
+`cvmfs_keys` | list of dicts | Keys to install on hosts of all types.
+`cvmfs_server_urls` | list of dicts | CVMFS server URLs, the value of `CVMFS_SERVER_URL` in `/etc/cvmfs/domain.d/<domain>.conf`.
+`cvmfs_repositories` | list of dicts | CVMFS repository configurations, the value of `CVMFS_REPOSITORIES` in `/etc/cvmfs/default.local` plus additional settings in `/etc/cvmfs/repositories.d/<repository>/{client,server}.conf`.
+`cvmfs_quota_limit` | integer in MB | Size of CVMFS client cache. Default is `4000`.
+`cvmfs_upgrade_client` | boolean | Upgrade CVMFS on clients to the latest version if it is already installed. Default is `false`.
+`cvmfs_install_setuid_cvmfs_wipecache` | boolean | Install a setuid binary on clients that allows unprivileged users to perform `cvmfs_config wipecache`. EL only (source is provided).
+`cvmfs_install_setuid_cvmfs_remount_sync` | boolean | Install a setuid binary on clients that allows unprivileged users to perform `cvmfs_talk remount sync`. EL only (source is provided).
+
+The complex (list of dict) variables have the following syntaxes:
+
+```yaml
+cvmfs_keys:
+  - path: 'absolute path to repo key.pub'
+    owner: 'user owning key file (default: root)'
+    key: |
+      -----BEGIN PUBLIC KEY-----
+      MIIBIjAN...
+
+cvmfs_server_urls:
+  - domain: 'repo parent domain'
+    urls:
+      - 'repository URL'
+
+cvmfs_repositories:
+  - repository: 'repo name'
+    stratum0: 'stratum 0 hostname'
+    owner: 'user owning repository (default: root)'
+    key_dir: 'path to directory containing repo keys (default: /etc/cvmfs/keys)'
+    server_options:
+      - KEY=val
+    client_options:
+      - KEY=val
+```
+
+## Server variables
+
+variable | type | description
+`cvmfs_private_keys` | list of dicts | Keys to install on Stratum 0 hosts. Separate from `cvmfs_keys` for vaultability and avoiding duplication.
+`cvmfs_config_apache` | boolean | Configure Apache on Stratum 0 and 1 servers. If disabled, you must configure it yourself. Default is `true`.
+`cvmfs_manage_firewall` | boolean | Attempt to configure firewalld (EL) or ufw (Debian) to permit traffic to configured ports. Default is `false`.
+`cvmfs_squid_conf_src` | path | Path to template Squid configuration file (for Stratum 1 and local proxy servers). Defaults are in the role `templates/` directory.
+`cvmfs_stratum0_http_ports` | list of integers | Port(s) to configure Apache on Stratum 0 servers to listen on. Default is `80`.
+`cvmfs_stratum1_http_ports` | list of integers | Port(s) to configure Squid on Stratum 1 servers to listen on. Default is `80` and `8000`.
+`cvmfs_stratum1_apache_port` | integer | Port to configure Apache on Stratum 1 servers to listen on. Default is `8008`.
+`cvmfs_stratum1_cache_mem` | integer in MB | Amount of memory for Squid to use for caching. Default is `128`.
+`cvmfs_stratum1_cache_dir` | list of dicts | 
+`cvmfs_localproxy_http_ports` | list of integers | Port(s) to configure Squid on local proxy servers to listen on.  Default is `3128`.
+`cvmfs_upgrade_server` | boolean | Upgrade CVMFS on servers to the latest version if it is already installed. Default is `false`.
+`cvmfs_srv_device` | path | Block device to create a filesystem on and mount for CVMFS data. Unset by default.
+`cvmfs_srv_fstype` | string | Filesystem to create on `cvmfs_srv_device`. Default is `ext4`.
+`cvmfs_srv_mount` | path | Path to mount CVMFS data volume on. Default is `/srv` (but is ignored if `cvmfs_srv_device` is unset).
+`cvmfs_union_fs` | string | Union filesystem type (`overlayfs` or `aufs`) for new repositories on Stratum 0 servers.
+`cvmfs_numfiles` | integer | Set the maximum number of open files in `/etc/security/limits.conf`. Useful with the `CVMFS_NFILES` client option on Stratum 0 servers.
+
+Additionally, setting the boolean `galaxy_cvmfs_repos_enabled` to `true` will automatically configure
+[galaxyproject.org][galaxy] repositories. You can override the defaults for Galaxy's `cvmfs_keys`, `cvmfs_server_urls`,
+and `cvmfs_repositories` by prepending `galaxy_` to the variable names. See the [defaults][defaults] for details.
+
+[defaults]: https://github.com/galaxyproject/ansible-cvmfs/blob/master/defaults/main.yml
 
 Dependencies
 ------------
@@ -36,7 +94,84 @@ None.
 Example Playbook
 ----------------
 
-TODO
+Configure all hosts as CVMFS clients with configurations for the Galaxy CVMFS repositories:
+
+```yaml
+- name: CVMFS
+  hosts: all
+  vars:
+    cvmfs_role: client
+    galaxy_cvmfs_repos_enabled: true
+  roles:
+    - geerlingguy.repo-epel
+    - galaxyproject.cvmfs
+```
+
+Create a Stratum 1 (mirror) of the Galaxy CVMFS repositories and configure clients to prefer your Stratum 1 (assuming
+you have configured hosts in groups `cvmfsclients` and `cvmfsstratum1servers`):
+
+```yaml
+- name: CVMFS
+  hosts: cvmfsclients:cvmfsstratum1servers
+  vars:
+    cvmfs_srv_device: /dev/sdb
+    galaxy_cvmfs_repos_enabled: true
+    # override the default
+    galaxy_cvmfs_server_urls:
+      - domain: galaxyproject.org
+        urls:
+          - "http://cvmfs.example.org/cvmfs/@fqrn@"
+          - "http://cvmfs1-psu0.galaxyproject.org/cvmfs/@fqrn@"
+          - "http://cvmfs1-iu0.galaxyproject.org/cvmfs/@fqrn@"
+          - "http://cvmfs1-tacc0.galaxyproject.org/cvmfs/@fqrn@"
+  roles:
+    - galaxyproject.cvmfs
+```
+
+Create your own CVMFS infrastructure. Run once without keys (new keys will be generated on repo creation):
+
+```yaml
+- name: CVMFS
+  hosts: cvmfsstratum0servers
+  vars:
+    cvmfs_numfiles: 4096
+    cvmfs_server_urls:
+      - domain: example.org
+        urls:
+          - "http://cvmfs0.example.org/cvmfs/@fqrn@"
+    cvmfs_repositories:
+      - repository: foo.example.org
+        stratum0: cvmfs0.example.org
+        key_dir: /etc/cvmfs/keys/example.org
+        server_options:
+          - CVMFS_AUTO_TAG=false
+          - CVMFS_GARBAGE_COLLECTION=true
+          - CVMFS_AUTO_GC=false
+        client_options:
+          - CVMFS_NFILES=4096
+      - repository: bar.example.org
+        stratum0: cvmfs0.example.org
+        key_dir: /etc/cvmfs/keys/example.org
+  roles:
+    - galaxyproject.cvmfs
+```
+
+Once keys have been created, add them to `cvmfs_keys` and run the same as above but `hosts: all` and `cvmfs_keys`
+defined as:
+
+```yaml
+- name: CVMFS
+  vars:
+    cvmfs_keys:
+      - path: /etc/cvmfs/keys/example.org/foo.example.org.pub
+        key: |
+          -----BEGIN PUBLIC KEY-----
+          MIIBIjAN...
+      - path: /etc/cvmfs/keys/example.org/bar.example.org.pub
+        key: |
+          -----BEGIN PUBLIC KEY-----
+          MIIBIjAN...
+```
 
 License
 -------
@@ -47,3 +182,6 @@ Author Information
 ------------------
 
 [Nate Coraor](https://github.com/natefoo)  
+[Helena Rasche](https://github.com/erasche)  
+
+[View contributors on GitHub](https://github.com/galaxyproject/ansible-cvmfs/graphs/contributors)

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ All variables are optional. However, if unset, the role will essentially do noth
 ## Client or shared client/server variables
 
 variable | type | description
+--- | --- | ---
 `cvmfs_role` | string | Type of CVMFS host: `client`, `stratum0`, `stratum1`, or `localproxy`. Alternatively, you may put hosts in to groups `cvmfsclients`, `cvmfsstratum0servers`, `cvmfsstratum1servers`, and `cvmfslocalproxies`. Controls what packages are installed and what configuration is performed.
 `cvmfs_keys` | list of dicts | Keys to install on hosts of all types.
 `cvmfs_server_urls` | list of dicts | CVMFS server URLs, the value of `CVMFS_SERVER_URL` in `/etc/cvmfs/domain.d/<domain>.conf`.
@@ -65,6 +66,7 @@ cvmfs_repositories:
 ## Server variables
 
 variable | type | description
+--- | --- | ---
 `cvmfs_private_keys` | list of dicts | Keys to install on Stratum 0 hosts. Separate from `cvmfs_keys` for vaultability and avoiding duplication.
 `cvmfs_config_apache` | boolean | Configure Apache on Stratum 0 and 1 servers. If disabled, you must configure it yourself. Default is `true`.
 `cvmfs_manage_firewall` | boolean | Attempt to configure firewalld (EL) or ufw (Debian) to permit traffic to configured ports. Default is `false`.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,47 @@
 ---
 # defaults file for galaxyproject.cvmfs
 
-cvmfs_keys:
+cvmfs_keys: []
+cvmfs_private_keys: []
+cvmfs_server_urls: []
+cvmfs_repositories: []
+cvmfs_http_proxies:
+  - DIRECT
+cvmfs_stratum1_servers: []
+
+cvmfs_stratum1_apache_port: 8008
+cvmfs_stratum1_cache_mem: 128 #MB
+
+# Whether the client or server should be upgraded or just installed if missing
+cvmfs_upgrade_client: false
+cvmfs_upgrade_server: false
+
+# Install a setuid binary allowing unprivileged users to call `cvmfs_config wipecache` or `cvmfs_talk remount sync`?
+cvmfs_install_setuid_cvmfs_wipecache: no
+cvmfs_install_setuid_cvmfs_remount_sync: no
+
+# Block device to mkfs/mount on stratum1s
+cvmfs_srv_device: true
+
+# Setup an optional cache directory for squid. Otherwise in-memory cache is used.
+# cvmfs_stratum1_cache_dir:
+#   dir: /var/cache/squid
+#   size: 1024 # 1 GB
+
+# You can manually specify a role if you don't want to or cannot use the
+# group_names
+cvmfs_role: '' # (client, Or stratum1 or stratum0 or localproxy)
+
+
+#
+# Galaxy-specific stuff follows
+#
+
+# Automatically configure Galaxy CVMFS repos
+galaxy_cvmfs_repos_enabled: false
+
+# Defaults for galaxyproject.org repos
+galaxy_cvmfs_keys:
   - path: /etc/cvmfs/keys/test.galaxyproject.org.pub
     owner: g2test
     key: |
@@ -169,16 +209,14 @@ cvmfs_keys:
       BDIF5yII
       -----END CERTIFICATE-----
 
-cvmfs_private_keys: []
-
-cvmfs_server_urls:
+galaxy_cvmfs_server_urls:
   - domain: galaxyproject.org
     urls:
-      - "http://cvmfs1-tacc0.galaxyproject.org/cvmfs/@fqrn@"
-      - "http://cvmfs1-iu0.galaxyproject.org/cvmfs/@fqrn@"
       - "http://cvmfs1-psu0.galaxyproject.org/cvmfs/@fqrn@"
+      - "http://cvmfs1-iu0.galaxyproject.org/cvmfs/@fqrn@"
+      - "http://cvmfs1-tacc0.galaxyproject.org/cvmfs/@fqrn@"
 
-cvmfs_repositories:
+galaxy_cvmfs_repositories:
   - repository: test.galaxyproject.org
     stratum0: cvmfs0-tacc0.galaxyproject.org
     owner: g2test
@@ -207,35 +245,3 @@ cvmfs_repositories:
     owner: singularity
     server_options: []
     client_options: []
-
-
-cvmfs_http_proxies:
-  - DIRECT
-
-cvmfs_stratum1_servers:
-  - "cvmfs1-tacc0.galaxyproject.org"
-  - "cvmfs1-iu0.galaxyproject.org"
-  - "cvmfs1-psu0.galaxyproject.org"
-
-cvmfs_stratum1_apache_port: 8008
-# in MB
-cvmfs_stratum1_cache_mem: 128
-
-# Whether the client or server should be upgraded or just installed if missing
-cvmfs_upgrade_client: false
-cvmfs_upgrade_server: false
-
-# Install a setuid binary allowing unprivileged users to call `cvmfs_config wipecache` or `cvmfs_talk remount sync`?
-cvmfs_install_setuid_cvmfs_wipecache: no
-cvmfs_install_setuid_cvmfs_remount_sync: no
-
-cvmfs_srv_device: true
-
-# Setup an optional cache directory for squid. Otherwise in-memory cache is used.
-# cvmfs_stratum1_cache_dir:
-#   dir: /var/cache/squid
-#   size: 1024 # 1 GB
-
-# You can manually specify a role if you don't want to or cannot use the
-# group_names
-cvmfs_role: '' # (client, Or stratum1 or stratum0 or localproxy)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,7 +7,16 @@ cvmfs_server_urls: []
 cvmfs_repositories: []
 cvmfs_http_proxies:
   - DIRECT
-cvmfs_stratum1_servers: []
+
+cvmfs_manage_firewall: false
+
+cvmfs_stratum0_http_ports:
+  - 80
+cvmfs_stratum1_http_ports:
+  - 80
+  - 8000
+cvmfs_localproxy_http_ports:
+  - 3128
 
 cvmfs_stratum1_apache_port: 8008
 cvmfs_stratum1_cache_mem: 128 #MB
@@ -20,8 +29,12 @@ cvmfs_upgrade_server: false
 cvmfs_install_setuid_cvmfs_wipecache: no
 cvmfs_install_setuid_cvmfs_remount_sync: no
 
-# Block device to mkfs/mount on stratum1s
-cvmfs_srv_device: true
+# Block device to mkfs/mount on stratum0s/stratum1s
+cvmfs_srv_device: false
+cvmfs_srv_mount: /srv
+
+cvmfs_union_fs: overlayfs
+cvmfs_config_apache: true
 
 # Setup an optional cache directory for squid. Otherwise in-memory cache is used.
 # cvmfs_stratum1_cache_dir:
@@ -43,7 +56,6 @@ galaxy_cvmfs_repos_enabled: false
 # Defaults for galaxyproject.org repos
 galaxy_cvmfs_keys:
   - path: /etc/cvmfs/keys/galaxyproject.org/test.galaxyproject.org.pub
-    owner: g2test
     key: |
       -----BEGIN PUBLIC KEY-----
       MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtfc5SSX9ALcrukWYcxkI
@@ -55,7 +67,6 @@ galaxy_cvmfs_keys:
       PwIDAQAB
       -----END PUBLIC KEY-----
   - path: /etc/cvmfs/keys/galaxyproject.org/data.galaxyproject.org.pub
-    owner: g2test
     key: |
       -----BEGIN PUBLIC KEY-----
       MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA5LHQuKWzcX5iBbCGsXGt
@@ -67,7 +78,6 @@ galaxy_cvmfs_keys:
       owIDAQAB
       -----END PUBLIC KEY-----
   - path: /etc/cvmfs/keys/galaxyproject.org/main.galaxyproject.org.pub
-    owner: g2main
     key: |
       -----BEGIN PUBLIC KEY-----
       MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA6S6Tugcv4kk4C06f574l
@@ -79,7 +89,6 @@ galaxy_cvmfs_keys:
       OQIDAQAB
       -----END PUBLIC KEY-----
   - path: /etc/cvmfs/keys/galaxyproject.org/sandbox.galaxyproject.org.pub
-    owner: root
     key: |
       -----BEGIN PUBLIC KEY-----
       MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA1jHnrwsxMUkMZDAj9GMt
@@ -91,7 +100,6 @@ galaxy_cvmfs_keys:
       YwIDAQAB
       -----END PUBLIC KEY-----
   - path: /etc/cvmfs/keys/galaxyproject.org/singularity.galaxyproject.org.pub
-    owner: root
     key: |
       -----BEGIN PUBLIC KEY-----
       MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAt977djqKnD4WbYNq8VtU

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -42,7 +42,7 @@ galaxy_cvmfs_repos_enabled: false
 
 # Defaults for galaxyproject.org repos
 galaxy_cvmfs_keys:
-  - path: /etc/cvmfs/keys/test.galaxyproject.org.pub
+  - path: /etc/cvmfs/keys/galaxyproject.org/test.galaxyproject.org.pub
     owner: g2test
     key: |
       -----BEGIN PUBLIC KEY-----
@@ -54,28 +54,7 @@ galaxy_cvmfs_keys:
       helU0HE2Rw/u9EqJDvPFTbUmad3MtspkqbG5Eo7lI+ktzbcD7UTsQ/7noIXIQ5dD
       PwIDAQAB
       -----END PUBLIC KEY-----
-  - path: /etc/cvmfs/keys/test.galaxyproject.org.crt
-    owner: g2test
-    key: |
-      -----BEGIN CERTIFICATE-----
-      MIIC9DCCAdwCCQC3lM3Z8xqGAjANBgkqhkiG9w0BAQsFADA8MTowOAYDVQQDDDF0
-      ZXN0LmdhbGF4eXByb2plY3Qub3JnIENlcm5WTS1GUyBSZWxlYXNlIE1hbmFnZXJz
-      MB4XDTE2MDMzMDAzMjkyN1oXDTE3MDMzMDAzMjkyN1owPDE6MDgGA1UEAwwxdGVz
-      dC5nYWxheHlwcm9qZWN0Lm9yZyBDZXJuVk0tRlMgUmVsZWFzZSBNYW5hZ2VyczCC
-      ASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALw45Jfo9SD2LX8fA3/fULz7
-      QQakPXc+s61dKIB7eBG5ZRd99IFu3RJbinn2/zx9V8fgsMPvj2fYyHqRJ2jUXsre
-      sIDLB8yEH97HLIUXwZFdA1RF+z1BTsH0PoUKeI/jQR2NqSEBBLOYQI3pFq+W7b32
-      gDl+uAasx4pc0VE6p/3Hfre7Fki0vNodcC4eZr8nr0vfkx8dDFm+7fTzqMjBCcNP
-      qp+vdqyH/D72qWzV5+Db0a2G5NhuPzd7/wjrSKH46L8BSgjIucx6YBYeXA5D1akR
-      oj+F/mygUHXx2XeAknjDN03jspRgSJGwcDxfvV3H9KRMrOi6Glt2AsxW9B6TbnsC
-      AwEAATANBgkqhkiG9w0BAQsFAAOCAQEAe4p3qRPHMGikobrcqZMfb2eOQCALMbxL
-      g52xyd85uoXtM/4HZl1Y5oaUdalfJET0T2mI0Nxt88GXkI6jtNsKJGg2SKlNrhCP
-      HzJRc0MZ+TvQFWWe23nY3krXKqWSXIT41AUMYz4t+BuJPb32y7cIFmX2SNPsaWFj
-      aOFCh39K3wq6OD1SEp3wWPUQqC6dQEiQthG/xRe8HBZXxyGuGsGuZbC5L6ltUEvn
-      QbKTk0xXXpBChXvEaSD1D5TATVUFbf8fwqHjkDVarhJxAtrv1p0k/EzJGrhbcEh+
-      ka2GnWe8NST2zVvhBhnKVErSMJa0ZVSikljy8/ftJ24gfCjDFf6mEg==
-      -----END CERTIFICATE-----
-  - path: /etc/cvmfs/keys/data.galaxyproject.org.pub
+  - path: /etc/cvmfs/keys/galaxyproject.org/data.galaxyproject.org.pub
     owner: g2test
     key: |
       -----BEGIN PUBLIC KEY-----
@@ -87,28 +66,7 @@ galaxy_cvmfs_keys:
       NVNhhcb66OJHah5ppI1N3cZehdaKyr1XcF9eedwLFTvuiwTn6qMmttT/tHX7rcxT
       owIDAQAB
       -----END PUBLIC KEY-----
-  - path: /etc/cvmfs/keys/data.galaxyproject.org.crt
-    owner: g2test
-    key: |
-      -----BEGIN CERTIFICATE-----
-      MIIC9DCCAdwCCQDHxOGBpJCTaTANBgkqhkiG9w0BAQsFADA8MTowOAYDVQQDDDFk
-      YXRhLmdhbGF4eXByb2plY3Qub3JnIENlcm5WTS1GUyBSZWxlYXNlIE1hbmFnZXJz
-      MB4XDTE2MDMzMTE3MTA1MloXDTE3MDMzMTE3MTA1MlowPDE6MDgGA1UEAwwxZGF0
-      YS5nYWxheHlwcm9qZWN0Lm9yZyBDZXJuVk0tRlMgUmVsZWFzZSBNYW5hZ2VyczCC
-      ASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBANSqVuz/IGAeN5FtRezgmMQH
-      MZR7Pu8BadU1yAPIAdkvg357xnF30UdzFFsx5UoIoaOTh07cFBpDZ/yD7evfbWFe
-      u2HrI0N6gnSGJDal6jaRzB2gslRcE4d5B2U30xg0bXqVq2ASACCA6Tr4h909w5Hs
-      qIT8mDN1kwg4yAC1CJ7lVEyd2omI/8FlJ+kONHOcKhuQzo/F4zSADYDk5bkJUFO2
-      b51YcumqefJ12dP5L7w2wqbVRzo2MxtZWDrVuxAGEr+DU8BX9MXrQwxOXHADmWFD
-      nCqlg0CoFR6CS2TzNcJdu0JmC/u+bgFeKkfekHiLg2RwhSYp0BLrxxUODXT7AHcC
-      AwEAATANBgkqhkiG9w0BAQsFAAOCAQEAW0lijt9nXWIFX+ZiS6GqowD0XNzoWwwa
-      05YHhivKlFzadBpsO9W5/Evq5Upi6plLQw0m2gYl6zaZKxXB5N90nvKqSL8tp4AZ
-      C+qJdwBSJjG+rWZLh71AgTAfbKFxQUQea4s1yq6Y/iM/KpQj3xvGWCTtPHNVFqgX
-      yc7Z5XE9YQIVsKO1Z4A1SVyp/F+xn9ikRfE1USuVXd14icPgSkLd4uCF1is9Ns2h
-      IVsc8y8pyu4e2uiuvAiDkIWDwTj5LwvQlzCeAn4Z2crBEMDXOg5Ax7DE+8K+VaS7
-      umt/c7usl22IscRFArkCPbTMJuUxyJYH8g9rl1AiziVw9zC9SCbD2w==
-      -----END CERTIFICATE-----
-  - path: /etc/cvmfs/keys/main.galaxyproject.org.pub
+  - path: /etc/cvmfs/keys/galaxyproject.org/main.galaxyproject.org.pub
     owner: g2main
     key: |
       -----BEGIN PUBLIC KEY-----
@@ -120,28 +78,7 @@ galaxy_cvmfs_keys:
       torRYcoFZICTZqY9e/KsadHUeZnH3RvfMypH5oS1POzsFszoSxBhZIBkZbG3/f9Y
       OQIDAQAB
       -----END PUBLIC KEY-----
-  - path: /etc/cvmfs/keys/main.galaxyproject.org.crt
-    owner: g2main
-    key: |
-      -----BEGIN CERTIFICATE-----
-      MIIC9DCCAdwCCQCu1/uoOM2BxjANBgkqhkiG9w0BAQsFADA8MTowOAYDVQQDDDFt
-      YWluLmdhbGF4eXByb2plY3Qub3JnIENlcm5WTS1GUyBSZWxlYXNlIE1hbmFnZXJz
-      MB4XDTE2MDQxMTE1MjkxN1oXDTE3MDQxMTE1MjkxN1owPDE6MDgGA1UEAwwxbWFp
-      bi5nYWxheHlwcm9qZWN0Lm9yZyBDZXJuVk0tRlMgUmVsZWFzZSBNYW5hZ2VyczCC
-      ASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALsxdKt+ol4QOGsIy3Z49m7s
-      uvfjFVwCXVBJcZMR1iaqIdqpVMn/9h4MQZn6npxwYFZ5zFirVs409kIDbUUNnF9V
-      eD16AEhgHuarXsoiFG7msy6YhXa2ErIoR378b7sF5fSBzcYlcgUJb2DzS3vr17H6
-      ZMxj0IMymdrynBaoUi5GyD7471cWr09onL8LSrO1gxXYVBl4RkLKIEOaRs8Kgf1g
-      trZE2rfJXqseQHUfGUGQH4jP++nNPSBNxQGyHMZxAPJe5OukcHpsp+QvtSJKNTkC
-      A4G1AEEbxw8bi3sER6tpzZEg3HuI8v03jOf5b/3bdHTAz3Au9jxO/h9sPqqszxsC
-      AwEAATANBgkqhkiG9w0BAQsFAAOCAQEAgJoWcG45RwS6VlkT7CDFyb1eVvt/i3aJ
-      XXPod2odg49zKBZ2pidKYkKSgmMfF6BKS3VIWW6Op5kZrw1gNSU22xMwqTHgkvOl
-      c13DZGZbsDlYL2hp7fFg3pLw2KFITY5B31PCOqrXXpgPQPL/uedV2bjGHcIeerPj
-      9GbQbSqSRNZ4Kq8mz4zjMPUC01nJL+S82Dz04JjIVqhT/bmMn67AeFqxBzN3B1wk
-      bAGzbVAm14suDOEoallf/MXSRkeU6J3hEGdWbAS/0HfyTpPzdlytyihvz5R0UDZp
-      3LfKBSCPAcZI4A1CecNIBgCvV3YT4qow68xovCmI9x7YXbdXwAA3Zw==
-      -----END CERTIFICATE-----
-  - path: /etc/cvmfs/keys/sandbox.galaxyproject.org.pub
+  - path: /etc/cvmfs/keys/galaxyproject.org/sandbox.galaxyproject.org.pub
     owner: root
     key: |
       -----BEGIN PUBLIC KEY-----
@@ -153,28 +90,7 @@ galaxy_cvmfs_keys:
       l5LILRbaIyXiTsFqXfK1dtjAOmZMkX4wuBch13y9FhMCIRvBDWYQuyxugSC101Ur
       YwIDAQAB
       -----END PUBLIC KEY-----
-  - path: /etc/cvmfs/keys/sandbox.galaxyproject.org.crt
-    owner: root
-    key: |
-      -----BEGIN CERTIFICATE-----
-      MIIC+jCCAeICCQCM+ld6uTJAGjANBgkqhkiG9w0BAQsFADA/MT0wOwYDVQQDDDRz
-      YW5kYm94LmdhbGF4eXByb2plY3Qub3JnIENlcm5WTS1GUyBSZWxlYXNlIE1hbmFn
-      ZXJzMB4XDTE4MDUwODA3NDEwN1oXDTE5MDUwODA3NDEwN1owPzE9MDsGA1UEAww0
-      c2FuZGJveC5nYWxheHlwcm9qZWN0Lm9yZyBDZXJuVk0tRlMgUmVsZWFzZSBNYW5h
-      Z2VyczCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAOZ/1mSV1X2X5NPi
-      B2b0v4Wep7+dwxLJR9ElKIx4ShzxY2fIT0XBjOGzBuaLRxOD52jA+mOFHa5Y2X65
-      BawRQWCsewK6Qxk3ihYoQdXEd78ahydhOOsY9UDrpxLlsVtHokK2t2Zme5a6AmS8
-      Rj4rwfBXErbCUiLK+BRSDWoIy2wvK3lErmFoXlr4cr7Yji9rAySytKWiTd49lneA
-      05v/KFy8iuef2Y3g33atPUnZMw4l6IHkuCj3YSaLjwmWIC4X7cuG9R7SMSm4HMoY
-      FKAVrDr+MxsGPIYZOWIbKlAcRXZHr2toOk/jZXBaezRP13W0zXL88ojdRXVv/U8L
-      UW4fmMUCAwEAATANBgkqhkiG9w0BAQsFAAOCAQEAlzl6mshHyJ3H47RMDATRQkNN
-      qDpIwaWftygAIJdnZWtiS0gut/NyN4l2lOz5mZ8cFzg2Y9JUGW+dtIwSW0QUvO4k
-      q5+0qWTeD9dixj/ERIpMOake/Z2Gzzro3gHe+P3NHZ0slsnKzVDIZFZo6x/Lc701
-      KENOt0oSF8kZTSxQoi0o0OBs5H3bA+afkNHxiXRwGG0nJ3sP2/MVrqrclYbLbRtA
-      uFjvHWE2X2fDmvvmxaKEdTq5Ip0TK41f0H2cyTROn0ofRjx3wp8KjX0D2JJqZIau
-      s6bKTTm3lyDf0+etkpE8J3TPbbSB/Ut+PCl8Efbzup1hmFpGZz/B89L9xi7+/w==
-      -----END CERTIFICATE-----
-  - path: /etc/cvmfs/keys/singularity.galaxyproject.org.pub
+  - path: /etc/cvmfs/keys/galaxyproject.org/singularity.galaxyproject.org.pub
     owner: root
     key: |
       -----BEGIN PUBLIC KEY-----
@@ -186,28 +102,6 @@ galaxy_cvmfs_keys:
       Zu859ZLVjmkMxPxEPNxgNnc+DohK5wFPt7MHSejvCmd1J8iL4DOXUN2VvgJ9NrUN
       hwIDAQAB
       -----END PUBLIC KEY-----
-  - path: /etc/cvmfs/keys/singularity.galaxyproject.org.crt
-    owner: root
-    key: |
-      -----BEGIN CERTIFICATE-----
-      MIIDAjCCAeoCCQD7gQ6vXswQHDANBgkqhkiG9w0BAQsFADBDMUEwPwYDVQQDDDhz
-      aW5ndWxhcml0eS5nYWxheHlwcm9qZWN0Lm9yZyBDZXJuVk0tRlMgUmVsZWFzZSBN
-      YW5hZ2VyczAeFw0xODA1MTAxMjEyMzdaFw0xOTA1MTAxMjEyMzdaMEMxQTA/BgNV
-      BAMMOHNpbmd1bGFyaXR5LmdhbGF4eXByb2plY3Qub3JnIENlcm5WTS1GUyBSZWxl
-      YXNlIE1hbmFnZXJzMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA7mlC
-      I6xxdekF0JTGi/wzBh5TVsm7JRZWZ7fRr7zE+WyxOGAD1qKckchqN168xd4a/7Rb
-      BRt5jGozziuPk86CjfP2C0B/KxPdNuD/ffBKPVBbEqkmMgv0YN2ycFLVIkg0HkAa
-      TGidRljIpGqQRFdjCNXNHnkax+mCU1+wxR9GfNR0HVO7G4PK57b279oZPotIn4h4
-      yBfhJrNZG2v9fdVfXT1188Pc98IUhrWjZQc/HjTRn+1i/NO8TJ8P76hC0nGlg4Ks
-      JxM42Onf2a9EeuJCdwgbwh7zzUdthCCOtOf0GCHchkhUXgO8qk3AKgYBGEJFexEE
-      ogJzRE8D+24seye8MQIDAQABMA0GCSqGSIb3DQEBCwUAA4IBAQAC1yKa2CHQnmmC
-      K5UXqYYN3eSWXB1KNiBzpKVDNvqqe6oVXKW4eDXZOmoSf5xeVxL5424fqp+ZHEH0
-      HoL4e1/GofbYtw382zEeeT4LHgDQ3gsAX18hQJK0k4M5YHIDDWHBpLBvBrzv4kyQ
-      i3u7qvXAUBb40eINU/4LdCsHMhxBwUS1hymc/ugG77uUTcw2UlkuRlTgqleFYeqE
-      ehwMznbk6ldXB03sf9+idJKzegHD8Hgol1odof/3IGt3hBBIRY8wdQJ7Fd65Svf7
-      br7UXF4V9HUbq5OYwhKVS58wtSMcn4nAmhuiA9qna9Yf6k8XzJYeVP1Z4vCal6L1
-      BDIF5yII
-      -----END CERTIFICATE-----
 
 galaxy_cvmfs_server_urls:
   - domain: galaxyproject.org

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -30,7 +30,7 @@ cvmfs_install_setuid_cvmfs_wipecache: no
 cvmfs_install_setuid_cvmfs_remount_sync: no
 
 # Block device to mkfs/mount on stratum0s/stratum1s
-cvmfs_srv_device: false
+#cvmfs_srv_device: false
 cvmfs_srv_mount: /srv
 
 cvmfs_union_fs: overlayfs
@@ -122,28 +122,33 @@ galaxy_cvmfs_repositories:
   - repository: test.galaxyproject.org
     stratum0: cvmfs0-tacc0.galaxyproject.org
     owner: g2test
+    key_dir: /etc/cvmfs/keys/galaxyproject.org
     server_options:
       - CVMFS_AUTO_GC=false
     client_options: []
   - repository: main.galaxyproject.org
     stratum0: cvmfs0-tacc0.galaxyproject.org
     owner: g2main
+    key_dir: /etc/cvmfs/keys/galaxyproject.org
     server_options:
       - CVMFS_AUTO_GC=false
     client_options: []
   - repository: data.galaxyproject.org
     stratum0: cvmfs0-psu0.galaxyproject.org
     owner: g2test
+    key_dir: /etc/cvmfs/keys/galaxyproject.org
     server_options:
       - CVMFS_AUTO_GC=false
     client_options: []
   - repository: sandbox.galaxyproject.org
     stratum0: cvmfs0-psu0.galaxyproject.org
     owner: sandbox
+    key_dir: /etc/cvmfs/keys/galaxyproject.org
     server_options: []
     client_options: []
   - repository: singularity.galaxyproject.org
     stratum0: cvmfs0-psu0.galaxyproject.org
     owner: singularity
+    key_dir: /etc/cvmfs/keys/galaxyproject.org
     server_options: []
     client_options: []

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -8,17 +8,15 @@
 
 - name: restart squid
   service:
-    name: squid
+    name: "{{ cvmfs_squid_service_name }}"
     state: restarted
 
 - name: restart apache
   service:
-    # FIXME: RHEL-specific
-    name: httpd
+    name: "{{ cvmfs_apache_service_name }}"
     state: restarted
 
 - name: reload apache
   service:
-    # FIXME: RHEL-specific
-    name: httpd
+    name: "{{ cvmfs_apache_service_name }}"
     state: reloaded

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -16,7 +16,7 @@ galaxy_info:
   # - CC-BY
   license: MIT
 
-  min_ansible_version: 2.3
+  min_ansible_version: 2.4
 
   # If this a Container Enabled role, provide the minimum Ansible Container version.
   # min_ansible_container_version:

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -35,18 +35,12 @@ galaxy_info:
   platforms:
     - name: EL
       versions:
-      - 6
-      - 7
-  # - name: Fedora
-  #   versions:
-  #   - all
-  #   - 25
-  # - name: SomePlatform
-  #   versions:
-  #   - all
-  #   - 1.0
-  #   - 7
-  #   - 99.99
+        - 6
+        - 7
+    - name: Ubuntu
+      versions:
+        - trusty
+        - xenial
 
   galaxy_tags:
     - system

--- a/tasks/apache.yml
+++ b/tasks/apache.yml
@@ -1,0 +1,7 @@
+---
+
+- name: Ensure Apache is enabled and running
+  service:
+    name: "{{ cvmfs_apache_service_name }}"
+    state: started
+    enabled: yes

--- a/tasks/client.yml
+++ b/tasks/client.yml
@@ -1,12 +1,12 @@
 ---
 
 - name: Include initial OS-specific tasks
-  include: "init_{{ ansible_os_family | lower}}.yml"
+  include_tasks: "init_{{ ansible_os_family | lower}}.yml"
   vars:
     _cvmfs_role: client
 
 - name: Include key setup tasks
-  include: keys.yml
+  include_tasks: keys.yml
 
 - name: Check CernVM-FS for setup
   command: cvmfs_config chksetup

--- a/tasks/client.yml
+++ b/tasks/client.yml
@@ -4,6 +4,7 @@
   include_tasks: "init_{{ ansible_os_family | lower}}.yml"
   vars:
     _cvmfs_role: client
+    _cvmfs_upgrade: "{{ cvmfs_upgrade_client }}"
 
 - name: Include key setup tasks
   include_tasks: keys.yml
@@ -38,7 +39,7 @@
     mode: 0644
   with_items: "{{ cvmfs_server_urls }}"
 
-- name: Configure CernVM-FS client settings
+- name: Configure CernVM-FS global client settings
   copy:
     content: |
       CVMFS_REPOSITORIES="{%- for repo in cvmfs_repositories -%}{{ ',' if loop.index0 > 0 else '' }}{{ repo.repository }}{%- endfor -%}"
@@ -48,6 +49,11 @@
     owner: root
     group: root
     mode: 0644
+
+- name: Include repository client options tasks
+  include_tasks: options.yml
+  vars:
+    _cvmfs_repo_option_key: client
 
 - name: Install cvmfs_wipecache setuid binary
   copy:

--- a/tasks/client.yml
+++ b/tasks/client.yml
@@ -3,7 +3,7 @@
 - name: Include initial OS-specific tasks
   include: "init_{{ ansible_os_family | lower}}.yml"
   vars:
-    cvmfs_role: client
+    _cvmfs_role: client
 
 - name: Include key setup tasks
   include: keys.yml

--- a/tasks/client.yml
+++ b/tasks/client.yml
@@ -1,33 +1,12 @@
 ---
 
-- name: Install CernVM-FS client (yum)
-  yum:
-    name: cvmfs
-    state: "{{ 'latest' if cvmfs_upgrade_client else 'present' }}"
-  when: ansible_os_family == "RedHat"
+- name: Include initial OS-specific tasks
+  include: "init_{{ ansible_os_family | lower}}.yml"
+  vars:
+    cvmfs_role: client
 
-- name: Install CernVM-FS client (apt)
-  apt:
-    name: cvmfs
-  when: ansible_os_family == "Debian"
-
-- name: Make CernVM-FS key directories
-  file:
-    state: directory
-    path: "{{ item.path | dirname }}"
-    owner: root
-    group: root
-    mode: 0755
-  with_items: "{{ cvmfs_keys }}"
-
-- name: Install CernVM-FS keys
-  copy:
-    content: "{{ item.key }}"
-    dest: "{{ item.path }}"
-    owner: root
-    group: root
-    mode: 0444
-  with_items: "{{ cvmfs_keys }}"
+- name: Include key setup tasks
+  include: keys.yml
 
 - name: Check CernVM-FS for setup
   command: cvmfs_config chksetup
@@ -52,10 +31,11 @@
   copy:
     content: |
       CVMFS_SERVER_URL="{{ item.urls | join(';') }}"
-    dest: "/etc/cvmfs/domain.d/{{ item.domain }}.conf"
-    owner: "root"
-    group: "root"
-    mode: "0644"
+      CVMFS_KEYS_DIR=/etc/cvmfs/keys/{{ item.domain }}
+    dest: /etc/cvmfs/domain.d/{{ item.domain }}.conf
+    owner: root
+    group: root
+    mode: 0644
   with_items: "{{ cvmfs_server_urls }}"
 
 - name: Configure CernVM-FS client settings
@@ -65,9 +45,9 @@
       CVMFS_HTTP_PROXY="{{ cvmfs_http_proxies | join(';') }}"
       CVMFS_QUOTA_LIMIT="{{ cvmfs_quota_limit | default('4000') }}"
     dest: "/etc/cvmfs/default.local"
-    owner: "root"
-    group: "root"
-    mode: "0644"
+    owner: root
+    group: root
+    mode: 0644
 
 - name: Install cvmfs_wipecache setuid binary
   copy:

--- a/tasks/client.yml
+++ b/tasks/client.yml
@@ -11,13 +11,22 @@
     name: cvmfs
   when: ansible_os_family == "Debian"
 
+- name: Make CernVM-FS key directories
+  file:
+    state: directory
+    path: "{{ item.path | dirname }}"
+    owner: root
+    group: root
+    mode: 0755
+  with_items: "{{ cvmfs_keys }}"
+
 - name: Install CernVM-FS keys
   copy:
     content: "{{ item.key }}"
     dest: "{{ item.path }}"
-    owner: "root"
-    group: "root"
-    mode: "0444"
+    owner: root
+    group: root
+    mode: 0444
   with_items: "{{ cvmfs_keys }}"
 
 - name: Check CernVM-FS for setup

--- a/tasks/firewall.yml
+++ b/tasks/firewall.yml
@@ -1,0 +1,18 @@
+---
+
+- name: Ensure http is not firewalled (firewalld)
+  firewalld:
+    port: "{{ item }}/tcp"
+    state: enabled
+    permanent: yes
+    immediate: yes
+  with_items: "{{ _cvmfs_http_ports }}"
+  when: ansible_os_family == "RedHat"
+
+- name: Ensure http is not firewalled (ufw)
+  ufw:
+    rule: allow
+    port: "{{ item }}"
+    proto: tcp
+  with_items: "{{ _cvmfs_http_ports }}"
+  when: ansible_os_family == "Debian"

--- a/tasks/gc.yml
+++ b/tasks/gc.yml
@@ -1,0 +1,12 @@
+---
+
+- name: Schedule garbage collection
+  cron:
+    name: cvmfs_gc_{{ item.1.repository }}
+    cron_file: ansible_cvmfs_gc
+    user: "{{ item.1.owner | default('root') }}"
+    job: output=$(/usr/bin/cvmfs_server gc -f -t '1 Jan 1970 00:00:00' {{ item.1.repository }} 2>&1) || echo "$output"
+    hour: 3
+    minute: "{{ item.0 }}"
+    weekday: 3
+  with_indexed_items: "{{ cvmfs_repositories }}"

--- a/tasks/init_debian.yml
+++ b/tasks/init_debian.yml
@@ -21,4 +21,4 @@
   apt:
     name: "{{ item }}"
     state: "{{ 'latest' if cvmfs_upgrade_server else 'present' }}"
-  with_items: "{{ cvmfs_packages[cvmfs_role] }}"
+  with_items: "{{ cvmfs_packages[_cvmfs_role] }}"

--- a/tasks/init_debian.yml
+++ b/tasks/init_debian.yml
@@ -16,3 +16,9 @@
 - name: Install CernVM apt key
   apt_key:
     url: https://cvmrepo.web.cern.ch/cvmrepo/apt/cernvm.gpg
+
+- name: Install CernVM-FS packages and dependencies (apt)
+  apt:
+    name: "{{ item }}"
+    state: "{{ 'latest' if cvmfs_upgrade_server else 'present' }}"
+  with_items: "{{ cvmfs_packages[cvmfs_role] }}"

--- a/tasks/init_debian.yml
+++ b/tasks/init_debian.yml
@@ -20,5 +20,5 @@
 - name: Install CernVM-FS packages and dependencies (apt)
   apt:
     name: "{{ item }}"
-    state: "{{ 'latest' if cvmfs_upgrade_server else 'present' }}"
+    state: "{{ 'latest' if _cvmfs_upgrade else 'present' }}"
   with_items: "{{ cvmfs_packages[_cvmfs_role] }}"

--- a/tasks/init_redhat.yml
+++ b/tasks/init_redhat.yml
@@ -62,4 +62,4 @@
   yum:
     name: "{{ item }}"
     state: "{{ 'latest' if cvmfs_upgrade_server else 'present' }}"
-  with_items: "{{ cvmfs_packages[cvmfs_role] }}"
+  with_items: "{{ cvmfs_packages[_cvmfs_role] }}"

--- a/tasks/init_redhat.yml
+++ b/tasks/init_redhat.yml
@@ -61,5 +61,5 @@
 - name: Install CernVM-FS packages and dependencies (yum)
   yum:
     name: "{{ item }}"
-    state: "{{ 'latest' if cvmfs_upgrade_server else 'present' }}"
+    state: "{{ 'latest' if _cvmfs_upgrade else 'present' }}"
   with_items: "{{ cvmfs_packages[_cvmfs_role] }}"

--- a/tasks/init_redhat.yml
+++ b/tasks/init_redhat.yml
@@ -57,3 +57,9 @@
     owner: "root"
     group: "root"
     mode: "0644"
+
+- name: Install CernVM-FS packages and dependencies (yum)
+  yum:
+    name: "{{ item }}"
+    state: "{{ 'latest' if cvmfs_upgrade_server else 'present' }}"
+  with_items: "{{ cvmfs_packages[cvmfs_role] }}"

--- a/tasks/keys.yml
+++ b/tasks/keys.yml
@@ -1,0 +1,19 @@
+---
+
+- name: Make CernVM-FS key directories
+  file:
+    state: directory
+    path: "{{ item.path | dirname }}"
+    owner: root
+    group: root
+    mode: 0755
+  with_items: "{{ cvmfs_keys }}"
+
+- name: Install CernVM-FS keys
+  copy:
+    content: "{{ item.key }}"
+    dest: "{{ item.path }}"
+    owner: "{{ item.owner | default('root') }}"
+    group: root
+    mode: 0444
+  with_items: "{{ cvmfs_keys }}"

--- a/tasks/localproxy.yml
+++ b/tasks/localproxy.yml
@@ -1,18 +1,14 @@
 ---
 
-- name: Install CernVM-FS local proxy dependencies (yum)
-  yum:
-    name: "{{ item }}"
-  with_items:
-    - squid
-  when: ansible_os_family == "RedHat"
+- name: Include initial OS-specific tasks
+  include: "init_{{ ansible_os_family | lower}}.yml"
+  vars:
+    cvmfs_role: localproxy
 
-- name: Install CernVM-FS local proxy dependencies (apt)
-  apt:
-    name: "{{ item }}"
-  with_items:
-    - squid
-  when: ansible_os_family == "Debian"
+- name: Include squid tasks
+  include: squid.yml
+  vars:
+    _cvmfs_squid_conf_src: "{{ cvmfs_squid_conf_src | default('localproxy_squid.conf.j2') }}"
 
 # Need to double check that this actually works (see the hosts_file directive)
 #- name: Create squid hosts file
@@ -23,16 +19,8 @@
 #  notify:
 #    - restart squid
 
-- name: Configure squid for local proxies
-  template:
-    src: localproxy_squid.conf.j2
-    dest: /etc/squid/squid.conf
-    backup: yes
-  notify:
-    - restart squid
-
-- name: Ensure squid is enabled and running
-  service:
-    name: squid
-    state: started
-    enabled: yes
+- name: Include firewall tasks
+  include: firewall.yml
+  vars:
+    _cvmfs_http_ports: "{{ cvmfs_http_ports | default(cvmfs_localproxy_http_ports) }}"
+  when: cvmfs_manage_firewall

--- a/tasks/localproxy.yml
+++ b/tasks/localproxy.yml
@@ -4,6 +4,7 @@
   include_tasks: "init_{{ ansible_os_family | lower}}.yml"
   vars:
     _cvmfs_role: localproxy
+    _cvmfs_upgrade: "{{ cvmfs_upgrade_server }}"
 
 - name: Include squid tasks
   include_tasks: squid.yml

--- a/tasks/localproxy.yml
+++ b/tasks/localproxy.yml
@@ -3,7 +3,7 @@
 - name: Include initial OS-specific tasks
   include: "init_{{ ansible_os_family | lower}}.yml"
   vars:
-    cvmfs_role: localproxy
+    _cvmfs_role: localproxy
 
 - name: Include squid tasks
   include: squid.yml

--- a/tasks/localproxy.yml
+++ b/tasks/localproxy.yml
@@ -1,12 +1,12 @@
 ---
 
 - name: Include initial OS-specific tasks
-  include: "init_{{ ansible_os_family | lower}}.yml"
+  include_tasks: "init_{{ ansible_os_family | lower}}.yml"
   vars:
     _cvmfs_role: localproxy
 
 - name: Include squid tasks
-  include: squid.yml
+  include_tasks: squid.yml
   vars:
     _cvmfs_squid_conf_src: "{{ cvmfs_squid_conf_src | default('localproxy_squid.conf.j2') }}"
 
@@ -20,7 +20,7 @@
 #    - restart squid
 
 - name: Include firewall tasks
-  include: firewall.yml
+  include_tasks: firewall.yml
   vars:
     _cvmfs_http_ports: "{{ cvmfs_http_ports | default(cvmfs_localproxy_http_ports) }}"
   when: cvmfs_manage_firewall

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,19 +1,15 @@
 ---
 # tasks file for galaxyproject.cvmfs
 
-- name: Prepare yum for CernVM installation
-  include: repo_redhat.yml
-  when: ansible_os_family == "RedHat"
-
-- name: Prepare apt for CernVM installation
-  include: repo_debian.yml
-  when: ansible_os_family == "Debian"
+- name: Set OS-specific variables
+  include_vars: "{{ ansible_os_family | lower }}.yml"
 
 - name: Set facts for Galaxy CVMFS repositories, if enabled
   set_fact:
     cvmfs_keys: "{{ cvmfs_keys }} + {{ galaxy_cvmfs_keys }}"
     cvmfs_server_urls: "{{ cvmfs_server_urls }} + {{ galaxy_cvmfs_server_urls }}"
     cvmfs_repositories: "{{ cvmfs_repositories }} + {{ galaxy_cvmfs_repositories }}"
+    cvmfs_config_apache_flag: "{{ '-p' if not cvmfs_config_apache else '' }}"
   when: galaxy_cvmfs_repos_enabled
 
 - include: client.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,14 +12,14 @@
     cvmfs_config_apache_flag: "{{ '-p' if not cvmfs_config_apache else '' }}"
   when: galaxy_cvmfs_repos_enabled
 
-- include: client.yml
+- include_tasks: client.yml
   when: "'cvmfsclients' in group_names or cvmfs_role == 'client'"
 
-- include: stratum1.yml
+- include_tasks: stratum1.yml
   when: "'cvmfsstratum1servers' in group_names or cvmfs_role == 'stratum1'"
 
-- include: stratum0.yml
+- include_tasks: stratum0.yml
   when: "'cvmfsstratum0servers' in group_names or cvmfs_role == 'stratum0'"
 
-- include: localproxy.yml
+- include_tasks: localproxy.yml
   when: "'cvmfslocalproxies' in group_names or cvmfs_role == 'localproxy'"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,6 +9,13 @@
   include: repo_debian.yml
   when: ansible_os_family == "Debian"
 
+- name: Set facts for Galaxy CVMFS repositories, if enabled
+  set_fact:
+    cvmfs_keys: "{{ cvmfs_keys }} + {{ galaxy_cvmfs_keys }}"
+    cvmfs_server_urls: "{{ cvmfs_server_urls }} + {{ galaxy_cvmfs_server_urls }}"
+    cvmfs_repositories: "{{ cvmfs_repositories }} + {{ galaxy_cvmfs_repositories }}"
+  when: galaxy_cvmfs_repos_enabled
+
 - include: client.yml
   when: "'cvmfsclients' in group_names or cvmfs_role == 'client'"
 

--- a/tasks/options.yml
+++ b/tasks/options.yml
@@ -1,0 +1,10 @@
+---
+
+- name: Set repository {{ _cvmfs_repo_option_key }} options
+  lineinfile:
+    dest: "/etc/cvmfs/repositories.d/{{ item.0.repository }}/{{ _cvmfs_repo_option_key }}.conf"
+    regexp: "^{{ item.1.split('=')[0] }}=.*"
+    line: "{{ item.1 }}"
+  with_subelements:
+    - "{{ cvmfs_repositories }}"
+    - "{{ _cvmfs_repo_option_key }}_options"

--- a/tasks/squid.yml
+++ b/tasks/squid.yml
@@ -1,0 +1,33 @@
+---
+
+- name: Configure squid
+  template:
+    src: "{{ _cvmfs_squid_conf_src }}"
+    dest: "{{ cvmfs_squid_conf_file }}"
+    backup: yes
+  notify:
+    - restart squid
+
+- name: Fix cache directory permission
+  file:
+    path: "{{ cvmfs_squid_cache_dir.dir }}"
+    owner: "{{ cvmfs_squid_user }}"
+    group: "{{ cvmfs_squid_group }}"
+    mode: 0755
+    state: directory
+    setype: squid_cache_t
+  when: cvmfs_squid_cache_dir is defined
+
+- name: Create the cache directories for the first time
+  become: true
+  become_user: "{{ cvmfs_squid_user }}"
+  command: squid -z
+  args:
+    creates: "{{ cvmfs_squid_cache_dir }}/00"
+  when: cvmfs_squid_cache_dir is defined
+
+- name: Ensure squid is enabled and started
+  service:
+    name: "{{ cvmfs_squid_service_name }}"
+    state: started
+    enabled: yes

--- a/tasks/stratum0.yml
+++ b/tasks/stratum0.yml
@@ -5,12 +5,12 @@
 # w/ xfs /tmp).
 
 - name: Include initial OS-specific tasks
-  include: "init_{{ ansible_os_family | lower }}.yml"
+  include_tasks: "init_{{ ansible_os_family | lower }}.yml"
   vars:
     _cvmfs_role: stratum0
 
 - name: Include key setup tasks
-  include: keys.yml
+  include_tasks: keys.yml
 
 - name: Install CernVM-FS private keys
   copy:
@@ -22,13 +22,13 @@
   with_items: "{{ cvmfs_private_keys }}"
 
 - name: Include stratumN tasks
-  include: stratumN.yml
+  include_tasks: stratumN.yml
 
 - name: Include Apache tasks
-  include: apache.yml
+  include_tasks: apache.yml
 
 - name: Include firewall tasks
-  include: firewall.yml
+  include_tasks: firewall.yml
   vars:
     _cvmfs_http_ports: "{{ cvmfs_stratum0_http_ports }}"
   when: cvmfs_manage_firewall
@@ -50,12 +50,12 @@
     - restart apache
 
 - name: Include repository server options tasks
-  include: options.yml
+  include_tasks: options.yml
   vars:
     _cvmfs_repo_option_key: server
 
 - name: Include repository server options tasks
-  include: options.yml
+  include_tasks: options.yml
   vars:
     _cvmfs_repo_option_key: client
 
@@ -80,4 +80,4 @@
     job: "/usr/bin/cvmfs_server resign {{ cvmfs_repositories | join(' ; /usr/bin/cvmfs_server resign ', attribute='repository' ) }}"
 
 - name: Include garbage collection tasks
-  include: gc.yml
+  include_tasks: gc.yml

--- a/tasks/stratum0.yml
+++ b/tasks/stratum0.yml
@@ -7,7 +7,7 @@
 - name: Include initial OS-specific tasks
   include: "init_{{ ansible_os_family | lower }}.yml"
   vars:
-    cvmfs_role: stratum0
+    _cvmfs_role: stratum0
 
 - name: Include key setup tasks
   include: keys.yml

--- a/tasks/stratum0.yml
+++ b/tasks/stratum0.yml
@@ -8,6 +8,7 @@
   include_tasks: "init_{{ ansible_os_family | lower }}.yml"
   vars:
     _cvmfs_role: stratum0
+    _cvmfs_upgrade: "{{ cvmfs_upgrade_server }}"
 
 - name: Include key setup tasks
   include_tasks: keys.yml
@@ -42,7 +43,7 @@
     - restart apache
 
 - name: Ensure repositories are imported
-  command: /usr/bin/cvmfs_server import -r {{ cvmfs_config_apache_flag }} -o {{ item.owner | default('root') }} -f overlayfs {{ item.repository }}
+  command: /usr/bin/cvmfs_server import -r {{ cvmfs_config_apache_flag }} -o {{ item.owner | default('root') }} -f {{ cvmfs_union_fs }} {{ item.repository }}
   args:
     creates: /etc/cvmfs/repositories.d/{{ item.repository }}
   with_items: "{{ cvmfs_repositories }}"
@@ -54,7 +55,7 @@
   vars:
     _cvmfs_repo_option_key: server
 
-- name: Include repository server options tasks
+- name: Include repository client options tasks
   include_tasks: options.yml
   vars:
     _cvmfs_repo_option_key: client

--- a/tasks/stratum0.yml
+++ b/tasks/stratum0.yml
@@ -4,36 +4,13 @@
 # fails if /tmp is xfs, although for some reason was fine on the PSU stratum 0
 # w/ xfs /tmp).
 
-- name: Install CernVM-FS server and dependencies (yum)
-  yum:
-    name: "{{ item }}"
-    state: "{{ 'latest' if cvmfs_upgrade_server else 'present' }}"
-  with_items:
-    - httpd
-    - cvmfs-server
-    - cvmfs-config-default
-    - cvmfs
-  when: ansible_os_family == "RedHat"
+- name: Include initial OS-specific tasks
+  include: "init_{{ ansible_os_family | lower }}.yml"
+  vars:
+    cvmfs_role: stratum0
 
-- name: Install CernVM-FS server and dependencies (apt)
-  apt:
-    name: "{{ item }}"
-    state: "{{ 'latest' if cvmfs_upgrade_server else 'present' }}"
-  with_items:
-    - apache2
-    - cvmfs-server
-    - cvmfs-config-default
-    - cvmfs
-  when: ansible_os_family == "Debian"
-
-- name: Install CernVM-FS keys
-  copy:
-    content: "{{ item.key }}"
-    dest: "{{ item.path }}"
-    owner: "root"
-    group: "root"
-    mode: "0444"
-  with_items: "{{ cvmfs_keys }}"
+- name: Include key setup tasks
+  include: keys.yml
 
 - name: Install CernVM-FS private keys
   copy:
@@ -44,71 +21,53 @@
     mode: "0400"
   with_items: "{{ cvmfs_private_keys }}"
 
-- name: Ensure Apache is enabled and running
-  service:
-    # FIXME: RHEL-specific
-    name: httpd
-    state: started
-    enabled: yes
+- name: Include stratumN tasks
+  include: stratumN.yml
 
-- name: Ensure Apache is not firewalled
-  # FIXME: RHEL-specific
-  firewalld:
-    service: http
-    state: enabled
-    permanent: yes
-    immediate: yes
-  # Some hosts may not be using firewalld
-  ignore_errors: true
+- name: Include Apache tasks
+  include: apache.yml
 
-- name: Ensure repositories exist for import
-  stat:
-    path: /srv/cvmfs/{{ item.repository }}
-  register: srv_cvmfs_repo_stat
+- name: Include firewall tasks
+  include: firewall.yml
+  vars:
+    _cvmfs_http_ports: "{{ cvmfs_stratum0_http_ports }}"
+  when: cvmfs_manage_firewall
+
+- name: Create repositories
+  command: /usr/bin/cvmfs_server mkfs {{ cvmfs_config_apache_flag }} -o {{ item.owner | default('root') }} -f {{ cvmfs_union_fs }} {{ item.repository }}
+  args:
+    creates: /srv/cvmfs/{{ item.repository }}
   with_items: "{{ cvmfs_repositories }}"
-  failed_when: not srv_cvmfs_repo_stat.stat.exists
+  notify:
+    - restart apache
 
 - name: Ensure repositories are imported
-  command: /usr/bin/cvmfs_server import -r -o {{ item.owner | default('root') }} -f aufs {{ item.repository }}
+  command: /usr/bin/cvmfs_server import -r {{ cvmfs_config_apache_flag }} -o {{ item.owner | default('root') }} -f overlayfs {{ item.repository }}
   args:
     creates: /etc/cvmfs/repositories.d/{{ item.repository }}
   with_items: "{{ cvmfs_repositories }}"
   notify:
     - restart apache
 
-- name: Set repository server options
-  lineinfile:
-    dest: "/etc/cvmfs/repositories.d/{{ item.0.repository }}/server.conf"
-    regexp: "^{{ item.1.split('=')[0] }}=.*"
-    line: "{{ item.1 }}"
-  with_subelements:
-    - "{{ cvmfs_repositories }}"
-    - server_options
+- name: Include repository server options tasks
+  include: options.yml
+  vars:
+    _cvmfs_repo_option_key: server
 
-- name: Set repository client options
-  lineinfile:
-    dest: "/etc/cvmfs/repositories.d/{{ item.0.repository }}/client.conf"
-    regexp: "^{{ item.1.split('=')[0] }}=.*"
-    line: "{{ item.1 }}"
-  with_subelements:
-    - "{{ cvmfs_repositories }}"
-    - client_options
+- name: Include repository server options tasks
+  include: options.yml
+  vars:
+    _cvmfs_repo_option_key: client
 
 - name: Increase default max file descriptor limit
   lineinfile:
     dest: "/etc/security/limits.conf"
     regexp: '^\*\s+{{ item }}\s+nofile\s+\d+$'
-    line: "*               {{ item }}    nofile          4096"
+    line: "*               {{ item }}    nofile          {{ cvmfs_numfiles }}"
   with_items:
     - soft
     - hard
-
-# This used to be necessary to work around https://github.com/moby/moby/issues/21748
-- name: Allow users to manage services
-  template:
-    src: 01-manage-units.rules.j2
-    dest: /etc/polkit-1/rules.d/01-manage-units.rules
-  when: cvmfs_manage_units_group is defined
+  when: cvmfs_numfiles is defined
 
 - name: Schedule key resignings
   cron:
@@ -120,13 +79,5 @@
     weekday: 2
     job: "/usr/bin/cvmfs_server resign {{ cvmfs_repositories | join(' ; /usr/bin/cvmfs_server resign ', attribute='repository' ) }}"
 
-- name: Schedule stratum0 garbage collection
-  cron:
-    name: cvmfs_gc_{{ item.1.repository }}
-    cron_file: ansible_cvmfs_stratum0_gc
-    user: "{{ item.1.owner | default('root') }}"
-    job: output=$(/usr/bin/cvmfs_server gc -f -t '1 Jan 1970 00:00:00' {{ item.1.repository }} 2>&1) || echo "$output"
-    hour: 3
-    minute: "{{ item.0 }}"
-    weekday: 3
-  with_indexed_items: "{{ cvmfs_repositories }}"
+- name: Include garbage collection tasks
+  include: gc.yml

--- a/tasks/stratum1.yml
+++ b/tasks/stratum1.yml
@@ -4,6 +4,7 @@
   include_tasks: "init_{{ ansible_os_family | lower}}.yml"
   vars:
     _cvmfs_role: stratum1
+    _cvmfs_upgrade: "{{ cvmfs_upgrade_server }}"
 
 - name: Include key setup tasks
   include_tasks: keys.yml

--- a/tasks/stratum1.yml
+++ b/tasks/stratum1.yml
@@ -36,7 +36,7 @@
   when: cvmfs_manage_firewall
 
 - name: Ensure replicas are configured
-  command: /usr/bin/cvmfs_server add-replica -o {{ item.owner | default('root') }} http://{{ item.stratum0 }}/cvmfs/{{ item.repository }} /etc/cvmfs/keys/{{ item.repository }}.pub
+  command: /usr/bin/cvmfs_server add-replica -o {{ item.owner | default('root') }} http://{{ item.stratum0 }}/cvmfs/{{ item.repository }} {{ item.key_dir | default('/etc/cvmfs/keys') }}/{{ item.repository }}.pub
   args:
     creates: /etc/cvmfs/repositories.d/{{ item.repository }}
   with_items: "{{ cvmfs_repositories }}"

--- a/tasks/stratum1.yml
+++ b/tasks/stratum1.yml
@@ -1,12 +1,12 @@
 ---
 
 - name: Include initial OS-specific tasks
-  include: "init_{{ ansible_os_family | lower}}.yml"
+  include_tasks: "init_{{ ansible_os_family | lower}}.yml"
   vars:
     _cvmfs_role: stratum1
 
 - name: Include key setup tasks
-  include: keys.yml
+  include_tasks: keys.yml
 
 - name: Change Apache listen port
   lineinfile:
@@ -19,18 +19,18 @@
     - reload apache
 
 - name: Include stratumN tasks
-  include: stratumN.yml
+  include_tasks: stratumN.yml
 
 - name: Include Apache tasks
-  include: apache.yml
+  include_tasks: apache.yml
 
 - name: Include squid tasks
-  include: squid.yml
+  include_tasks: squid.yml
   vars:
     _cvmfs_squid_conf_src: "{{ cvmfs_squid_conf_src | default('stratum1_squid.conf.j2') }}"
 
 - name: Include firewall tasks
-  include: firewall.yml
+  include_tasks: firewall.yml
   vars:
     _cvmfs_http_ports: "{{ cvmfs_http_ports | default(cvmfs_stratum1_http_ports) }}"
   when: cvmfs_manage_firewall
@@ -44,7 +44,7 @@
     - restart apache
 
 - name: Include repository server options tasks
-  include: options.yml
+  include_tasks: options.yml
   vars:
     _cvmfs_repo_option_key: server
 
@@ -67,7 +67,7 @@
     minute: "*/5"
 
 - name: Include garbage collection tasks
-  include: gc.yml
+  include_tasks: gc.yml
 
 # allow unprivileged users to restart squid
 - name: Allow users to manage services

--- a/tasks/stratum1.yml
+++ b/tasks/stratum1.yml
@@ -1,108 +1,39 @@
 ---
 
-- name: Create /srv filesystem
-  filesystem:
-    dev: "{{ cvmfs_srv_device }}"
-    force: no
-    fstype: ext4
-  when: cvmfs_srv_device
+- name: Include initial OS-specific tasks
+  include: "init_{{ ansible_os_family | lower}}.yml"
+  vars:
+    cvmfs_role: stratum1
 
-- name: Mount /srv
-  mount:
-    name: /srv
-    src: "{{ cvmfs_srv_device }}"
-    fstype: ext4
-    state: mounted
-  when: cvmfs_srv_device
-
-- name: Install CernVM-FS server and dependencies (yum)
-  yum:
-    name: "{{ item }}"
-    state: "{{ 'latest' if cvmfs_upgrade_server else 'present' }}"
-  with_items:
-    - httpd
-    - mod_wsgi
-    - squid
-    - cvmfs-server
-    - cvmfs-config-default
-  when: ansible_os_family == "RedHat"
-
-- name: Install CernVM-FS server and dependencies (apt)
-  apt:
-    name: "{{ item }}"
-    state: "{{ 'latest' if cvmfs_upgrade_server else 'present' }}"
-  with_items:
-    - apache2
-    - cvmfs-server
-    - cvmfs-config-default
-  when: ansible_os_family == "Debian"
-
-- name: Install CernVM-FS keys
-  copy:
-    content: "{{ item.key }}"
-    dest: "{{ item.path }}"
-    owner: "{{ item.owner | default('root') }}"
-    group: "root"
-    mode: "0444"
-  with_items: "{{ cvmfs_keys }}"
+- name: Include key setup tasks
+  include: keys.yml
 
 - name: Change Apache listen port
   lineinfile:
-    # FIXME: RHEL-specific
-    dest: /etc/httpd/conf/httpd.conf
+    dest: "{{ cvmfs_apache_conf_file }}"
     line: "Listen {{ cvmfs_stratum1_apache_port }}"
     regexp: "^Listen\\s+"
     backup: yes
+  when: cvmfs_config_apache
   notify:
     - reload apache
 
-- name: Ensure Apache is enabled and running
-  service:
-    # FIXME: RHEL-specific
-    name: httpd
-    state: started
-    enabled: yes
+- name: Include stratumN tasks
+  include: stratumN.yml
 
-- name: Configure squid for stratum 1 proxy
-  template:
-    src: "{{ cvmfs_stratum1_squid_conf_src | default('stratum1_squid.conf.j2') }}"
-    dest: /etc/squid/squid.conf
-    backup: yes
-  notify:
-    - restart squid
+- name: Include Apache tasks
+  include: apache.yml
 
-- name: Fix cache directory permission
-  file:
-    path: "{{ cvmfs_stratum1_cache_dir.dir }}"
-    owner: squid
-    group: squid
-    mode: 0755
-    state: directory
-    setype: squid_cache_t
-  when: cvmfs_stratum1_cache_dir is defined
+- name: Include squid tasks
+  include: squid.yml
+  vars:
+    _cvmfs_squid_conf_src: "{{ cvmfs_squid_conf_src | default('stratum1_squid.conf.j2') }}"
 
-- name: Create the cache directories for the first time
-  become: true
-  become_user: squid
-  command: squid -z
-  args:
-    creates: "{{ cvmfs_stratum1_cache_dir }}/00"
-  when: cvmfs_stratum1_cache_dir is defined
-
-- name: Ensure squid is enabled and started
-  service:
-    name: squid
-    state: started
-    enabled: yes
-
-- name: Ensure Squid is not firewalled 
-  # FIXME: RHEL-specific
-  firewalld:
-    service: http
-    state: enabled
-    permanent: yes
-    immediate: yes
-  ignore_errors: true
+- name: Include firewall tasks
+  include: firewall.yml
+  vars:
+    _cvmfs_http_ports: "{{ cvmfs_http_ports | default(cvmfs_stratum1_http_ports) }}"
+  when: cvmfs_manage_firewall
 
 - name: Ensure replicas are configured
   command: /usr/bin/cvmfs_server add-replica -o {{ item.owner | default('root') }} http://{{ item.stratum0 }}/cvmfs/{{ item.repository }} /etc/cvmfs/keys/{{ item.repository }}.pub
@@ -112,14 +43,10 @@
   notify:
     - restart apache
 
-- name: Set repository server options
-  lineinfile:
-    dest: "/etc/cvmfs/repositories.d/{{ item.0.repository }}/server.conf"
-    regexp: "^{{ item.1.split('=')[0] }}=.*"
-    line: "{{ item.1 }}"
-  with_subelements:
-    - "{{ cvmfs_repositories }}"
-    - server_options
+- name: Include repository server options tasks
+  include: options.yml
+  vars:
+    _cvmfs_repo_option_key: server
 
 - name: Create CVMFS stratum1 logrotate configuration
   copy:
@@ -131,13 +58,6 @@
       }
     dest: /etc/logrotate.d/cvmfs
 
-- name: Remove per-repository snapshot cron jobs
-  cron:
-    name: cvmfs_snapshot_{{ item.repository }}
-    cron_file: ansible_cvmfs_stratum1_snapshot
-    state: absent
-  with_items: "{{ cvmfs_repositories }}"
-
 - name: Schedule stratum1 snapshots
   cron:
     name: cvmfs_snapshot_all
@@ -146,17 +66,10 @@
     job: output=$(/usr/bin/cvmfs_server snapshot -a -i 2>&1) || echo "$output"
     minute: "*/5"
 
-- name: Schedule stratum1 garbage collection
-  cron:
-    name: cvmfs_gc_{{ item.1.repository }}
-    cron_file: ansible_cvmfs_stratum1_gc
-    user: "{{ item.1.owner | default('root') }}"
-    job: output=$(/usr/bin/cvmfs_server gc -f -t '1 Jan 1970 00:00:00' {{ item.1.repository }} 2>&1) || echo "$output"
-    hour: 3
-    minute: "{{ item.0 }}"
-    weekday: 3
-  with_indexed_items: "{{ cvmfs_repositories }}"
+- name: Include garbage collection tasks
+  include: gc.yml
 
+# allow unprivileged users to restart squid
 - name: Allow users to manage services
   template:
     src: 01-manage-units.rules.j2

--- a/tasks/stratum1.yml
+++ b/tasks/stratum1.yml
@@ -3,7 +3,7 @@
 - name: Include initial OS-specific tasks
   include: "init_{{ ansible_os_family | lower}}.yml"
   vars:
-    cvmfs_role: stratum1
+    _cvmfs_role: stratum1
 
 - name: Include key setup tasks
   include: keys.yml

--- a/tasks/stratumN.yml
+++ b/tasks/stratumN.yml
@@ -5,7 +5,7 @@
     dev: "{{ cvmfs_srv_device }}"
     force: no
     fstype: "{{ cvmfs_srv_fstype | default('ext4') }}"
-  when: cvmfs_srv_device
+  when: cvmfs_srv_device is defined
 
 - name: Mount /srv
   mount:
@@ -13,4 +13,4 @@
     src: "{{ cvmfs_srv_device }}"
     fstype: "{{ cvmfs_srv_fstype | default('ext4') }}"
     state: mounted
-  when: cvmfs_srv_device
+  when: cvmfs_srv_device is defined

--- a/tasks/stratumN.yml
+++ b/tasks/stratumN.yml
@@ -1,0 +1,16 @@
+---
+
+- name: Create /srv filesystem
+  filesystem:
+    dev: "{{ cvmfs_srv_device }}"
+    force: no
+    fstype: "{{ cvmfs_srv_fstype | default('ext4') }}"
+  when: cvmfs_srv_device
+
+- name: Mount /srv
+  mount:
+    name: "{{ cvmfs_srv_mount }}"
+    src: "{{ cvmfs_srv_device }}"
+    fstype: "{{ cvmfs_srv_fstype | default('ext4') }}"
+    state: mounted
+  when: cvmfs_srv_device

--- a/vars/debian.yml
+++ b/vars/debian.yml
@@ -1,0 +1,23 @@
+---
+
+cvmfs_apache_service_name: apache2
+cvmfs_apache_conf_file: /etc/apache2/apache2.conf
+
+cvmfs_squid_service_name: squid
+cvmfs_squid_conf_file: /etc/squid/squid.conf
+cvmfs_squid_user: proxy
+cvmfs_squid_group: proxy
+
+cvmfs_packages:
+  stratum0:
+    - apache2
+    - cvmfs-server
+    - cvmfs-config-default
+  stratum1:
+    - apache2
+    - cvmfs-server
+    - cvmfs-config-default
+  localproxy:
+    - squid
+  client:
+    - cvmfs

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for galaxyproject.cvmfs

--- a/vars/redhat.yml
+++ b/vars/redhat.yml
@@ -1,0 +1,26 @@
+---
+
+cvmfs_apache_service_name: httpd
+cvmfs_apache_conf_file: /etc/httpd/conf/httpd.conf
+
+cvmfs_squid_service_name: squid
+cvmfs_squid_conf_file: /etc/squid/squid.conf
+cvmfs_squid_user: squid
+cvmfs_squid_group: squid
+
+cvmfs_packages:
+  stratum0:
+    - httpd
+    - cvmfs-server
+    - cvmfs-config-default
+    - cvmfs
+  stratum1:
+    - httpd
+    - mod_wsgi
+    - squid
+    - cvmfs-server
+    - cvmfs-config-default
+  localproxy:
+    - squid
+  client:
+    - cvmfs


### PR DESCRIPTION
Make this a more generic role that does not automatically configure Galaxy CVMFS repos by default (but retain a single config option to enable them) to make this more suitable for uploading to Ansible Galaxy for general consumption.