### PR TITLE
[DEPRECATION WARNING]: Invoking yum only once while using a loop via …

### DIFF
--- a/tasks/init_debian.yml
+++ b/tasks/init_debian.yml
@@ -36,6 +36,5 @@
 
 - name: Install CernVM-FS packages and dependencies (apt)
   apt:
-    name: "{{ item }}"
+    name: "{{ cvmfs_packages[_cvmfs_role] }}"
     state: "{{ 'latest' if _cvmfs_upgrade else 'present' }}"
-  with_items: "{{ cvmfs_packages[_cvmfs_role] }}"

--- a/tasks/init_redhat.yml
+++ b/tasks/init_redhat.yml
@@ -60,6 +60,5 @@
 
 - name: Install CernVM-FS packages and dependencies (yum)
   yum:
-    name: "{{ item }}"
+    name: "{{ cvmfs_packages[_cvmfs_role] }}"
     state: "{{ 'latest' if _cvmfs_upgrade else 'present' }}"
-  with_items: "{{ cvmfs_packages[_cvmfs_role] }}"


### PR DESCRIPTION
```
[DEPRECATION WARNING]: Invoking "yum" only once while using a loop via squash_actions is deprecated. Instead of using a loop to supply multiple items and specifying `name: {{ item }}`, please use
`name: u'{{ cvmfs_packages[_cvmfs_role] }}'` and remove the loop. This feature will be removed in version 2.11. Deprecation warnings can be disabled by setting deprecation_warnings=False in
ansible.cfg.
```

https://docs.ansible.com/ansible/2.7/porting_guides/porting_guide_2.7.html#using-a-loop-on-a-package-module-via-squash-actions

By the way, great job! It works out of the box.