### PR TITLE
Add support for the cvmfs-config.galaxyproject.org config repo

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -49,12 +49,51 @@ cvmfs_role: '' # (client, Or stratum1 or stratum0 or localproxy)
 cvmfs_preload_install: false
 cvmfs_preload_path: /usr/bin
 
+# Support for CVMFS config repositories - see galaxy_cvmfs_config_repo for syntax
+cvmfs_config_repo: {}
+
+# CVMFS_CONFIG_REPOSITORY is not supported on Debian < 9, Ubuntu LTS < 18.04
+cvmfs_config_repo_supported: >-
+  {{
+    'true' if ansible_os_family != 'Debian' else (
+    'true' if (ansible_distribution == 'Debian' and ansible_distribution_version is version('9', '>=')) else (
+    'true' if (ansible_distribution == 'Ubuntu' and ansible_distribution_version is version('18.04', '>=')) else
+    'false'))
+  }}
+
 #
 # Galaxy-specific stuff follows
 #
 
 # Automatically configure Galaxy CVMFS repos
 galaxy_cvmfs_repos_enabled: false
+
+# Defaults for galaxyproject.org config repo, syntax for each key is the same as that of cvmfs_<key | pluralize>
+galaxy_cvmfs_config_repo:
+  domain: galaxyproject.org
+  key:
+    path: /etc/cvmfs/keys/galaxyproject.org/cvmfs-config.galaxyproject.org.pub
+    key: |
+     -----BEGIN PUBLIC KEY-----
+     MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAuJZTWTY3/dBfspFKifv8
+     TWuuT2Zzoo1cAskKpKu5gsUAyDFbZfYBEy91qbLPC3TuUm2zdPNsjCQbbq1Liufk
+     uNPZJ8Ubn5PR6kndwrdD13NVHZpXVml1+ooTSF5CL3x/KUkYiyRz94sAr9trVoSx
+     THW2buV7ADUYivX7ofCvBu5T6YngbPZNIxDB4mh7cEal/UDtxV683A/5RL4wIYvt
+     S5SVemmu6Yb8GkGwLGmMVLYXutuaHdMFyKzWm+qFlG5JRz4okUWERvtJ2QAJPOzL
+     mAG1ceyBFowj/r3iJTa+Jcif2uAmZxg+cHkZG5KzATykF82UH1ojUzREMMDcPJi2
+     dQIDAQAB
+     -----END PUBLIC KEY-----
+  urls:
+    - "http://cvmfs1-psu0.galaxyproject.org/cvmfs/@fqrn@"
+    - "http://cvmfs1-iu0.galaxyproject.org/cvmfs/@fqrn@"
+    - "http://cvmfs1-tacc0.galaxyproject.org/cvmfs/@fqrn@"
+    # TODO: add .eu and .org.eu Stratum 1s once they have replicated the config repo
+  repository:
+    repository: cvmfs-config.galaxyproject.org
+    stratum0: cvmfs0-psu0.galaxyproject.org
+    owner: "{{ cvmfs_repo_owner | default('root') }}"
+    server_options: []
+    client_options: []
 
 # Defaults for galaxyproject.org repos
 galaxy_cvmfs_keys:
@@ -113,6 +152,17 @@ galaxy_cvmfs_keys:
       Zu859ZLVjmkMxPxEPNxgNnc+DohK5wFPt7MHSejvCmd1J8iL4DOXUN2VvgJ9NrUN
       hwIDAQAB
       -----END PUBLIC KEY-----
+  - path: /etc/cvmfs/keys/galaxyproject.org/usegalaxy.galaxyproject.org.pub
+    key: |
+      -----BEGIN PUBLIC KEY-----
+      MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsqb8HIG5T/juOmVpByIE
+      UfboKj7S2LbnWCZdCAoA9EfQfsxi/p3iWu1j9/0iJjf4yKs+pI6mJL/t+txB9fM5
+      EYdYJv/awH7W4A47e8/CR25HzoM9PjxbssRbHSGWLrDBPHUcyQh7gZGqJYdXIyeS
+      DrgPoftn04xuLQvmPWbi8Ng14c+Kn8947PxZ5hVOmApEd4gzkHI0qFfC7dTN/rTh
+      KdC5mWONdRmmSDM4OmgJl7wdzE5pUTA+H1GagESxG4Cm/7EN9ZnVgWdb/sgVTxHG
+      e3odhIy/hV82RHkaW456/jhd8tD8LHpY8jdM/rWvwrBgI7WntqSijOUe2a6uC7S1
+      sQIDAQAB
+      -----END PUBLIC KEY-----
 
 galaxy_cvmfs_server_urls:
   - domain: galaxyproject.org
@@ -127,34 +177,40 @@ galaxy_cvmfs_server_urls:
 galaxy_cvmfs_repositories:
   - repository: test.galaxyproject.org
     stratum0: cvmfs0-tacc0.galaxyproject.org
-    owner: g2test
+    owner: "{{ cvmfs_repo_owner | default('root') }}"
     key_dir: /etc/cvmfs/keys/galaxyproject.org
     server_options:
       - CVMFS_AUTO_GC=false
     client_options: []
   - repository: main.galaxyproject.org
     stratum0: cvmfs0-tacc0.galaxyproject.org
-    owner: g2main
+    owner: "{{ cvmfs_repo_owner | default('root') }}"
     key_dir: /etc/cvmfs/keys/galaxyproject.org
     server_options:
       - CVMFS_AUTO_GC=false
     client_options: []
   - repository: data.galaxyproject.org
     stratum0: cvmfs0-psu0.galaxyproject.org
-    owner: g2test
+    owner: "{{ cvmfs_repo_owner | default('root') }}"
     key_dir: /etc/cvmfs/keys/galaxyproject.org
     server_options:
       - CVMFS_AUTO_GC=false
     client_options: []
   - repository: sandbox.galaxyproject.org
     stratum0: cvmfs0-psu0.galaxyproject.org
-    owner: sandbox
+    owner: "{{ cvmfs_repo_owner | default('root') }}"
     key_dir: /etc/cvmfs/keys/galaxyproject.org
     server_options: []
     client_options: []
   - repository: singularity.galaxyproject.org
     stratum0: cvmfs0-psu0.galaxyproject.org
-    owner: singularity
+    owner: "{{ cvmfs_repo_owner | default('root') }}"
+    key_dir: /etc/cvmfs/keys/galaxyproject.org
+    server_options: []
+    client_options: []
+  - repository: usegalaxy.galaxyproject.org
+    stratum0: cvmfs0-psu0.galaxyproject.org
+    owner: "{{ cvmfs_repo_owner | default('root') }}"
     key_dir: /etc/cvmfs/keys/galaxyproject.org
     server_options: []
     client_options: []

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -17,7 +17,7 @@ galaxy_info:
   # - CC-BY
   license: MIT
 
-  min_ansible_version: 2.4
+  min_ansible_version: 2.5
 
   # If this a Container Enabled role, provide the minimum Ansible Container version.
   # min_ansible_container_version:

--- a/tasks/client.yml
+++ b/tasks/client.yml
@@ -1,4 +1,5 @@
 ---
+
 - name: Include initial OS-specific tasks
   include_tasks: "init_{{ ansible_os_family | lower }}.yml"
   vars:
@@ -27,16 +28,44 @@
   args:
     creates: /etc/auto.cvmfs
 
+- name: Configure CernVM-FS config repository
+  block:
+
+    - name: Create config repo config
+      copy:
+        content: |
+          ## This file is maintained by Ansible - CHANGES WILL BE OVERWRITTEN
+          CVMFS_SERVER_URL="{{ cvmfs_config_repo.urls | join(';') }}"
+          CVMFS_PUBLIC_KEY="{{ cvmfs_config_repo.key.path }}"
+        dest: /etc/cvmfs/config.d/{{ cvmfs_config_repo.repository.repository }}.conf
+        owner: root
+        group: root
+        mode: 0444
+
+    - name: Set config repo defaults
+      copy:
+        content: |
+          ## This file is maintained by Ansible - CHANGES WILL BE OVERWRITTEN
+          CVMFS_CONFIG_REPOSITORY="{{ cvmfs_config_repo.repository.repository }}"
+          CVMFS_DEFAULT_DOMAIN="{{ cvmfs_config_repo.domain }}"
+          CVMFS_USE_GEOAPI="{{ item.use_geoapi | ternary('yes', 'no') }}"
+        dest: /etc/cvmfs/default.d/80-ansible-galaxyproject-cvmfs.conf
+        owner: root
+        group: root
+        mode: 0444
+
+  when: cvmfs_config_repo and cvmfs_config_repo_supported
+
 - name: Configure CernVM-FS domain
   copy:
     content: |
+      ## This file is maintained by Ansible - CHANGES WILL BE OVERWRITTEN
       CVMFS_SERVER_URL="{{ item.urls | join(';') }}"
       CVMFS_KEYS_DIR=/etc/cvmfs/keys/{{ item.domain }}
-      CVMFS_USE_GEOAPI="{{ item.use_geoapi | ternary('yes', 'no') }}"
     dest: /etc/cvmfs/domain.d/{{ item.domain }}.conf
     owner: root
     group: root
-    mode: 0644
+    mode: 0444
   with_items: "{{ cvmfs_server_urls }}"
 
 - name: Configure CernVM-FS global client settings

--- a/tasks/keys.yml
+++ b/tasks/keys.yml
@@ -8,6 +8,8 @@
     group: root
     mode: 0755
   with_items: "{{ cvmfs_keys }}"
+  loop_control:
+    label: "{{ item.path }}"
 
 - name: Install CernVM-FS keys
   copy:
@@ -17,3 +19,5 @@
     group: root
     mode: 0444
   with_items: "{{ cvmfs_keys }}"
+  loop_control:
+    label: "{{ item.path }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,13 +4,22 @@
 - name: Set OS-specific variables
   include_vars: "{{ ansible_os_family | lower }}.yml"
 
-- name: Set facts for Galaxy CVMFS repositories, if enabled
+- name: Set facts for Galaxy CVMFS config repository, if enabled
+  set_fact:
+    cvmfs_config_repo: "{{ galaxy_cvmfs_config_repo }}"
+  when: galaxy_cvmfs_repos_enabled and galaxy_cvmfs_repos_enabled == 'config-repo'
+
+- name: Set facts for Galaxy CVMFS static repositories, if enabled
   set_fact:
     cvmfs_keys: "{{ cvmfs_keys }} + {{ galaxy_cvmfs_keys }}"
-    cvmfs_server_urls: "{{ cvmfs_server_urls }} + {{ galaxy_cvmfs_server_urls }}"
     cvmfs_repositories: "{{ cvmfs_repositories }} + {{ galaxy_cvmfs_repositories }}"
-    cvmfs_config_apache_flag: "{{ '-p' if not cvmfs_config_apache else '' }}"
-  when: galaxy_cvmfs_repos_enabled
+    cvmfs_server_urls: "{{ cvmfs_server_urls }} + {{ galaxy_cvmfs_server_urls }}"
+  when: galaxy_cvmfs_repos_enabled and galaxy_cvmfs_repos_enabled != 'config-repo'
+
+- name: Set facts for CVMFS config repository, if enabled
+  set_fact:
+    cvmfs_keys: "{{ cvmfs_keys }} + [{{ cvmfs_config_repo.key }}]"
+  when: cvmfs_config_repo
 
 - include_tasks: client.yml
   when: "'cvmfsclients' in group_names or cvmfs_role == 'client'"

--- a/tasks/stratum0.yml
+++ b/tasks/stratum0.yml
@@ -4,6 +4,10 @@
 # fails if /tmp is xfs, although for some reason was fine on the PSU stratum 0
 # w/ xfs /tmp).
 
+- name: Determine whether -p flag is needed for cvmfs_server mkfs or import
+  set_fact:
+    cvmfs_config_apache_flag: "{{ '-p' if not cvmfs_config_apache else '' }}"
+
 - name: Include initial OS-specific tasks
   include_tasks: "init_{{ ansible_os_family | lower }}.yml"
   vars:
@@ -21,6 +25,8 @@
     group: "root"
     mode: "0400"
   with_items: "{{ cvmfs_private_keys }}"
+  loop_control:
+    label: "{{ item.path }}"
 
 - name: Include stratumN tasks
   include_tasks: stratumN.yml


### PR DESCRIPTION
...and some other small improvements.

I'd resisted creating a [CVMFS Config Repository](https://cvmfs.readthedocs.io/en/stable/cpt-configure.html#the-config-repository) in the past because you still have to install a client config. But as I added yet another new repo (usegalaxy.galaxyproject.org for [usegalaxy-tools](https://github.com/galaxyproject/usegalaxy-tools)) getting everything distributed for it became too tedious.

Instead of setting `galaxy_cvmfs_repos_enabled` to something that evaluates true, you can now set it to the string `config-repo` and only get the config needed to mount/use the cvmfs-config.galaxyproject.org repo. The previous behavior with static configs is still supported as well if it evaluates true and is anything other than `config-repo`.

Other improvements:

- Prioritize documentation about the `galaxy_cvmfs_repos_enabled` option since that's probably what most people want.
- General support for CVMFS config repositories (not just Galaxy's)
- Don't reference users in `galaxy_cvmfs_keys` that probably don't exist (this would only be relevant to people setting up Stratum 1s)
- Fix a bug with `cvmfs_config_apache_flag`
- Remove owner write bit from managed configs and add a managed warning
- Clean up Ansible runtime output a bit


xref: galaxyproject/galaxy-hub#536