### PR TITLE
Changes for new singularity.galaxyproject.org

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -86,15 +86,15 @@ galaxy_cvmfs_config_repo:
   key:
     path: /etc/cvmfs/keys/galaxyproject.org/cvmfs-config.galaxyproject.org.pub
     key: |
-     -----BEGIN PUBLIC KEY-----
-     MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAuJZTWTY3/dBfspFKifv8
-     TWuuT2Zzoo1cAskKpKu5gsUAyDFbZfYBEy91qbLPC3TuUm2zdPNsjCQbbq1Liufk
-     uNPZJ8Ubn5PR6kndwrdD13NVHZpXVml1+ooTSF5CL3x/KUkYiyRz94sAr9trVoSx
-     THW2buV7ADUYivX7ofCvBu5T6YngbPZNIxDB4mh7cEal/UDtxV683A/5RL4wIYvt
-     S5SVemmu6Yb8GkGwLGmMVLYXutuaHdMFyKzWm+qFlG5JRz4okUWERvtJ2QAJPOzL
-     mAG1ceyBFowj/r3iJTa+Jcif2uAmZxg+cHkZG5KzATykF82UH1ojUzREMMDcPJi2
-     dQIDAQAB
-     -----END PUBLIC KEY-----
+      -----BEGIN PUBLIC KEY-----
+      MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAuJZTWTY3/dBfspFKifv8
+      TWuuT2Zzoo1cAskKpKu5gsUAyDFbZfYBEy91qbLPC3TuUm2zdPNsjCQbbq1Liufk
+      uNPZJ8Ubn5PR6kndwrdD13NVHZpXVml1+ooTSF5CL3x/KUkYiyRz94sAr9trVoSx
+      THW2buV7ADUYivX7ofCvBu5T6YngbPZNIxDB4mh7cEal/UDtxV683A/5RL4wIYvt
+      S5SVemmu6Yb8GkGwLGmMVLYXutuaHdMFyKzWm+qFlG5JRz4okUWERvtJ2QAJPOzL
+      mAG1ceyBFowj/r3iJTa+Jcif2uAmZxg+cHkZG5KzATykF82UH1ojUzREMMDcPJi2
+      dQIDAQAB
+      -----END PUBLIC KEY-----
   urls:
     - "http://cvmfs1-psu0.galaxyproject.org/cvmfs/@fqrn@"
     - "http://cvmfs1-iu0.galaxyproject.org/cvmfs/@fqrn@"
@@ -110,6 +110,18 @@ galaxy_cvmfs_config_repo:
 
 # Defaults for galaxyproject.org repos
 galaxy_cvmfs_keys:
+  # This will become the key for all repos, currently cvmfs-config and singularity
+  - path: /etc/cvmfs/keys/galaxyproject.org/galaxyproject.org.pub
+    key: |
+      -----BEGIN PUBLIC KEY-----
+      MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAuJZTWTY3/dBfspFKifv8
+      TWuuT2Zzoo1cAskKpKu5gsUAyDFbZfYBEy91qbLPC3TuUm2zdPNsjCQbbq1Liufk
+      uNPZJ8Ubn5PR6kndwrdD13NVHZpXVml1+ooTSF5CL3x/KUkYiyRz94sAr9trVoSx
+      THW2buV7ADUYivX7ofCvBu5T6YngbPZNIxDB4mh7cEal/UDtxV683A/5RL4wIYvt
+      S5SVemmu6Yb8GkGwLGmMVLYXutuaHdMFyKzWm+qFlG5JRz4okUWERvtJ2QAJPOzL
+      mAG1ceyBFowj/r3iJTa+Jcif2uAmZxg+cHkZG5KzATykF82UH1ojUzREMMDcPJi2
+      dQIDAQAB
+      -----END PUBLIC KEY-----
   - path: /etc/cvmfs/keys/galaxyproject.org/test.galaxyproject.org.pub
     key: |
       -----BEGIN PUBLIC KEY-----
@@ -153,17 +165,6 @@ galaxy_cvmfs_keys:
       WDNbviUi62sBl1SWQ95kcsfqfviU94DKGWRWDYngnYRV5PZVLuUw8Egix6lW2Sj0
       l5LILRbaIyXiTsFqXfK1dtjAOmZMkX4wuBch13y9FhMCIRvBDWYQuyxugSC101Ur
       YwIDAQAB
-      -----END PUBLIC KEY-----
-  - path: /etc/cvmfs/keys/galaxyproject.org/singularity.galaxyproject.org.pub
-    key: |
-      -----BEGIN PUBLIC KEY-----
-      MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAt977djqKnD4WbYNq8VtU
-      v9b8BgFzo1wh8rEUdj/2W9IvLXr5iWRrk1OvyZugYGxUg2JSVxiSXJhP1m8uBfBG
-      aX2jn4iAq1suuIxJ6UMO+SYR/9yUANY/JKvfI9qHN9ItXxYveRXwORWb6s3zyCm3
-      FFTRTUVQ5NFC+yT13BeIKyLMhT8yMSnlZ/5f8kuwSC1v/2QcC6UWDrHaUcEGWcHS
-      EfiTov/pVXq0Hv3M2kwBWMqWeFey4WbnuNOCXYrYy9VCxmPAtO0TjFuThMr9XyWc
-      Zu859ZLVjmkMxPxEPNxgNnc+DohK5wFPt7MHSejvCmd1J8iL4DOXUN2VvgJ9NrUN
-      hwIDAQAB
       -----END PUBLIC KEY-----
   - path: /etc/cvmfs/keys/galaxyproject.org/usegalaxy.galaxyproject.org.pub
     key: |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -217,7 +217,7 @@ galaxy_cvmfs_repositories:
     server_options: []
     client_options: []
   - repository: singularity.galaxyproject.org
-    stratum0: cvmfs0-psu0.galaxyproject.org
+    stratum0: cvmfs-stratum0.galaxyproject.eu
     owner: "{{ cvmfs_repo_owner | default('root') }}"
     key_dir: /etc/cvmfs/keys/galaxyproject.org
     server_options: []


### PR DESCRIPTION
After many space/storage problems on cvmfs0-psu0.galaxyproject.org, the `singularity.galaxyproject.org` repo has been rebuilt using resources kindly provided by Galaxy Europe (presumably via de.NBI), courtesy @gmauro and @bgruening.

If you have a stratum 1 copy of this repo, you should `cvmfs_server rmfs singularity.galaxyproject.org` and reinitialize the copy using the new stratum 0 URL, `http://cvmfs-stratum0.galaxyproject.eu`. There is currently an active mirror on `cvmfs1-psu0.galaxyproject.org`. Neither of the other two stratum 1 servers I operate (cvmfs1-tacc0, cvmfs1-iu0) has adequate storage for this repo at the moment, unfortunately.

Also, it turns out that we should have been using a single signing key for all of our repos, so I have initiated the process of converting us to a single key by signing with the key for the `cvmfs-config.galaxyproject.org` repo. If you have a CVMFS client and you are already using the config repo (which eventually we will decommission), you should be able to mount this repo without any changes. Otherwise, install this key in `/etc/cvmfs/keys/galaxyproject.org/galaxyproject.org.pub`:

```
-----BEGIN PUBLIC KEY-----
MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAuJZTWTY3/dBfspFKifv8
TWuuT2Zzoo1cAskKpKu5gsUAyDFbZfYBEy91qbLPC3TuUm2zdPNsjCQbbq1Liufk
uNPZJ8Ubn5PR6kndwrdD13NVHZpXVml1+ooTSF5CL3x/KUkYiyRz94sAr9trVoSx
THW2buV7ADUYivX7ofCvBu5T6YngbPZNIxDB4mh7cEal/UDtxV683A/5RL4wIYvt
S5SVemmu6Yb8GkGwLGmMVLYXutuaHdMFyKzWm+qFlG5JRz4okUWERvtJ2QAJPOzL
mAG1ceyBFowj/r3iJTa+Jcif2uAmZxg+cHkZG5KzATykF82UH1ojUzREMMDcPJi2
dQIDAQAB
-----END PUBLIC KEY-----
```