### PR TITLE
Add refgenomes-databio.galaxyproject.org repo

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -210,6 +210,13 @@ galaxy_cvmfs_repositories:
     server_options:
       - CVMFS_AUTO_GC=false
     client_options: []
+  - repository: refgenomes-databio.galaxyproject.org
+    stratum0: cvmfs0-psu0.galaxyproject.org
+    owner: "{{ cvmfs_repo_owner | default('root') }}"
+    key_dir: /etc/cvmfs/keys/galaxyproject.org
+    server_options:
+      - CVMFS_AUTO_GC=false
+    client_options: []
   - repository: sandbox.galaxyproject.org
     stratum0: cvmfs0-psu0.galaxyproject.org
     owner: "{{ cvmfs_repo_owner | default('root') }}"


### PR DESCRIPTION
The key is the same as `cvmfs-config.galaxyproject.org` and `singularity.galaxyproject.org` as I am slowly unifying them to a single key (as per the best practice).