### PR TITLE
Add squid as Stratum 1 dependency for debian

### DIFF
--- a/vars/debian.yml
+++ b/vars/debian.yml
@@ -15,6 +15,7 @@ cvmfs_packages:
     - cvmfs-config-default
   stratum1:
     - apache2
+    - squid
     - cvmfs-server
     - cvmfs-config-default
   localproxy:


### PR DESCRIPTION
I am running into an issue with setting up a Stratum 1 on Ubuntu systems, because Squid doesn't get installed:

```
TASK [galaxyproject.cvmfs : Configure squid] ***********************************************************************************************************
fatal: [127.0.0.1]: FAILED! => {"changed": false, "checksum": "653ddf9c797f0fc5f68de2e22e4039b9768e531e", "msg": "Destination directory /etc/squid does not exist"}
```

Squid is listed in the Redhat package list as a dependency for the Stratum 1, but it's not in the Debian list. Could this be added?