### PR TITLE
Fix stratum 0/1 garbage collection cron job, use cvmfs_server gc -a

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -45,6 +45,42 @@ cvmfs_config_apache: true
 # group_names
 cvmfs_role: '' # (client, Or stratum1 or stratum0 or localproxy)
 
+# Specify whether `cvmfs_server gc -a` should be run from cron to garbage collect all repos on the server, disable this
+# option if your repos don't use CVMFS_AUTO_GC=false.
+cvmfs_gc_enabled: true
+
+# Garbage collection log path (directory will be created if necessary). This is the default path but CVMFS packages
+# don't precreate the directory for you so `cvmfs_server gc -a` will fail by default.
+cvmfs_gc_log: /var/log/cvmfs/gc.log
+
+# User to run garbage collection as. This user must have permission to gc all repositories on the server (i.e. it should
+# be `root` if you have repositories owned by multiple users)
+cvmfs_gc_user: root
+
+# Specify the options passed to `cvmfs_server gc`. If you override these you will need to include `-a -f` in your value
+# or the job will fail
+cvmfs_gc_options: "-a -f -L {{ cvmfs_gc_log }}"
+
+# Garbage collection cron job timing, hash keys correspond to the cron module options:
+#   https://docs.ansible.com/ansible/latest/collections/ansible/builtin/cron_module.html
+#
+#cvmfs_gc_time:
+#  special_time:
+#  hour:
+#  minute:
+#  day:
+#  month:
+#  weekday:
+#
+# e.g. for 3 AM nightly:
+#cvmfs_gc_time:
+#  hour: 3
+#  minute: 0
+#
+# Use @weekly by default:
+cvmfs_gc_time:
+  special_time: weekly
+
 # Optionally download the preload utility
 cvmfs_preload_install: false
 cvmfs_preload_path: /usr/bin

--- a/tasks/gc.yml
+++ b/tasks/gc.yml
@@ -1,12 +1,29 @@
 ---
 
+# gc -a support implemented in 2021/02, this task can be removed at some later date
+- name: Remove per-repository garbage collection cron jobs
+  cron:
+    name: cvmfs_gc_{{ item.repository }}
+    cron_file: ansible_cvmfs_gc
+    state: absent
+  loop: "{{ cvmfs_repositories }}"
+
+- name: Create garbage collection log directory
+  file:
+    path: "{{ cvmfs_gc_log | dirname }}"
+    state: directory
+    owner: "{{ cvmfs_gc_user }}"
+    mode: 0755
+
 - name: Schedule garbage collection
   cron:
-    name: cvmfs_gc_{{ item.1.repository }}
-    cron_file: ansible_cvmfs_gc
-    user: "{{ item.1.owner | default('root') }}"
-    job: output=$(/usr/bin/cvmfs_server gc -f -t '1 Jan 1970 00:00:00' {{ item.1.repository }} 2>&1) || echo "$output"
-    hour: 3
-    minute: "{{ item.0 }}"
-    weekday: 3
-  with_indexed_items: "{{ cvmfs_repositories }}"
+    name: cvmfs_gc_all
+    cron_file: ansible_cvmfs_gc_all
+    user: "{{ cvmfs_gc_user }}"
+    job: /usr/bin/cvmfs_server gc {{ cvmfs_gc_options }}
+    hour: "{{ cvmfs_gc_time.hour | default(omit) }}"
+    minute: "{{ cvmfs_gc_time.minute | default(omit) }}"
+    day: "{{ cvmfs_gc_time.day | default(omit) }}"
+    month: "{{ cvmfs_gc_time.month | default(omit) }}"
+    weekday: "{{ cvmfs_gc_time.weekday | default(omit) }}"
+    special_time: "{{ cvmfs_gc_time.special_time | default(omit) }}"

--- a/tasks/stratum0.yml
+++ b/tasks/stratum0.yml
@@ -88,3 +88,4 @@
 
 - name: Include garbage collection tasks
   include_tasks: gc.yml
+  when: cvmfs_gc_enabled

--- a/tasks/stratum1.yml
+++ b/tasks/stratum1.yml
@@ -114,6 +114,7 @@
 
 - name: Include garbage collection tasks
   include_tasks: gc.yml
+  when: cvmfs_gc_enabled
 
 # allow unprivileged users to restart squid
 - name: Allow users to manage services


### PR DESCRIPTION
As previously written, the loop would cause the gc cron jobs to overwrite eachother and only the last entry in `cvmfs_repositories` would exist. Not sure why as the cron module docs don't suggest there's anything wrong with how we were doing it, but oh well. Using the `-a` option to gc all repos is cleaner anyway. The only drawback is that it has to run as root, but I don't think this is a big deal.