### PR TITLE
Pass key directory to cvmfs_server add-replica command

### DIFF
--- a/tasks/stratum1.yml
+++ b/tasks/stratum1.yml
@@ -48,7 +48,7 @@
   command: >-
     /usr/bin/cvmfs_server add-replica -o {{ item.owner | default('root') }}
       http://{{ item.stratum0 }}/cvmfs/{{ item.repository }}
-      {{ item.key_dir | default('/etc/cvmfs/keys') }}/{{ item.repository }}.pub
+      {{ item.key_dir | default('/etc/cvmfs/keys') }}
   args:
     creates: /etc/cvmfs/repositories.d/{{ item.repository }}
   loop: "{{ cvmfs_repositories }}"


### PR DESCRIPTION
Instead of specifying an individual public key to the `add-replica` command on the Stratum 1, you can also pass the directory containing the public key(s):
```
  add-replica     [-u stratum1 upstream storage] [-o owner] [-w stratum1 url]
                  [-a silence apache warning] [-z enable garbage collection]
                  [-n alias name] [-s S3 config file] [-p no apache config]
                  [-g snapshot group] [-P pass-through repository]
                  <stratum 0 url> <public key | keys directory>
                  Creates a Stratum 1 replica of a Stratum 0 repository
```

This is very useful if you have one domain that reuses the master key for its repositories, so you can also use a single public key for all repos under that domain. Right now it's not really possible to use that feature, without just copying the same public key several times in the configuration. With this patch, you can just add a single public key to the configuration that can be used for all repositories (the name of the pub file doesn't really matter, the command will check all keys in the given directory).