### PR TITLE
Removed ".repo" extension

### DIFF
--- a/tasks/init_redhat.yml
+++ b/tasks/init_redhat.yml
@@ -4,7 +4,7 @@
   action:
     module: yum_repository
   args:
-    file: "cernvm.repo"
+    file: "cernvm"
     name: "{{ item.name }}"
     description: "{{ item.description }}"
     baseurl: "{{ item.baseurl }}"

--- a/tasks/init_redhat.yml
+++ b/tasks/init_redhat.yml
@@ -1,9 +1,16 @@
 ---
 
+- name: Remove legacy yum repo file if present
+  yum_repository:
+    file: "cernvm.repo"
+    name: "{{ item }}"
+    state: absent
+  loop:
+    - cernvm
+    - cernvm-config
+
 - name: Configure CernVM yum repositories
-  action:
-    module: yum_repository
-  args:
+  yum_repository:
     file: "cernvm"
     name: "{{ item.name }}"
     description: "{{ item.description }}"
@@ -12,7 +19,7 @@
     gpgcheck: yes
     enabled: yes
     protect: yes
-  with_items:
+  loop:
     - name: cernvm
       description: "CernVM packages"
       baseurl: "http://cvmrepo.web.cern.ch/cvmrepo/yum/cvmfs/EL/$releasever/$basearch/"


### PR DESCRIPTION
Removed ".repo" extension from file attribute of yum_repository. Per Ansible documentation, it is not needed (https://docs.ansible.com/ansible/latest/collections/ansible/builtin/yum_repository_module.html). Including it, the file ends up with the name cernvm.repo.repo.

