### PR TITLE
Use the file module to remove per-repo gc crontab files

### DIFF
--- a/tasks/gc.yml
+++ b/tasks/gc.yml
@@ -2,9 +2,8 @@
 
 # gc -a support implemented in 2021/02, this task can be removed at some later date
 - name: Remove per-repository garbage collection cron jobs
-  cron:
-    name: cvmfs_gc_{{ item.repository }}
-    cron_file: ansible_cvmfs_gc
+  file:
+    path: /etc/cron.d/cvmfs_gc_{{ item.repository }}
     state: absent
   loop: "{{ cvmfs_repositories }}"
 


### PR DESCRIPTION
The cron module requires the `user` param when `cron_file` is specified, even if `state` is `absent`, so just use the file module to remove the file instead.

Fixes #33.