### PR TITLE
Fix setting client options on clients

### DIFF
--- a/tasks/options.yml
+++ b/tasks/options.yml
@@ -1,10 +1,19 @@
 ---
 
+- name: Ensure per-repository directories exist for repositories with {{ _cvmfs_repo_option_key }} options defined
+  file:
+    path: "/etc/cvmfs/repositories.d/{{ item.repository }}"
+    mode: 0755
+    state: directory
+  loop: "{{ cvmfs_repositories }}"
+  loop_control:
+    label: "/etc/cvmfs/repositories.d/{{ item.repository }}"
+  when: "_cvmfs_repo_option_key ~ '_options' in item"
+
 - name: Set repository {{ _cvmfs_repo_option_key }} options
   lineinfile:
     dest: "/etc/cvmfs/repositories.d/{{ item.0.repository }}/{{ _cvmfs_repo_option_key }}.conf"
     regexp: "^{{ item.1.split('=')[0] }}=.*"
     line: "{{ item.1 }}"
-  with_subelements:
-    - "{{ cvmfs_repositories }}"
-    - "{{ _cvmfs_repo_option_key }}_options"
+    create: true
+  loop: "{{ cvmfs_repositories | subelements(_cvmfs_repo_option_key ~ '_options', skip_missing=true) }}"


### PR DESCRIPTION
Fixes #38.

This also makes it possible to not set `client_options` or `server_options` on entries in `cvmfs_repositories`.