### PR TITLE
Fixed the syntax for combining two lists

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,9 +11,9 @@
 
 - name: Set facts for Galaxy CVMFS static repositories, if enabled
   set_fact:
-    cvmfs_keys: "{{ cvmfs_keys }} + {{ galaxy_cvmfs_keys }}"
-    cvmfs_repositories: "{{ cvmfs_repositories }} + {{ galaxy_cvmfs_repositories }}"
-    cvmfs_server_urls: "{{ cvmfs_server_urls }} + {{ galaxy_cvmfs_server_urls }}"
+    cvmfs_keys: "{{ cvmfs_keys + galaxy_cvmfs_keys }}"
+    cvmfs_repositories: "{{ cvmfs_repositories + galaxy_cvmfs_repositories }}"
+    cvmfs_server_urls: "{{ cvmfs_server_urls + galaxy_cvmfs_server_urls }}"
   when: galaxy_cvmfs_repos_enabled and galaxy_cvmfs_repos_enabled != 'config-repo'
 
 - name: Set facts for CVMFS config repository, if enabled


### PR DESCRIPTION
The way lists were combined in tasks/main.yml breaks the role in ansible-core 2.13.x. The resulting variable then contains two separate lists, instead of a combined list.
As far as I could find the syntax `"{{ list1 + list2 }}"` is also the correct syntax to combine multiple lists into a single one. 
