### PR TITLE
Fix cvmfs_key when galaxy repo is disabled

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,7 +18,7 @@
 
 - name: Set facts for CVMFS config repository, if enabled
   set_fact:
-    cvmfs_keys: "{{ cvmfs_keys + galaxy_cvmfs_keys }}"
+    cvmfs_keys: "{{ cvmfs_keys + [cvmfs_config_repo.key] }}"
   # In Ansible >= 2.10 this will be | truthy
   when: cvmfs_config_repo | length > 0
 


### PR DESCRIPTION
The commit 26463045 introduced a bug where the galaxy_cvmfs_keys are now
added to cvmfs_keys instead of the cvmfs_config_repo.key, which results
in the wrong keys to be installed on the host. This PR is an attempt to fix that bug.