### PR TITLE
Add Jammy (22.04) to list of supported Ubuntu versions

### DIFF
--- a/tasks/init_debian.yml
+++ b/tasks/init_debian.yml
@@ -22,7 +22,7 @@
     filename: "cernvm.list"
     mode: 422
     repo: "deb [allow-insecure=true] https://cvmrepo.web.cern.ch/cvmrepo/apt/ {{ ansible_distribution_release }}-prod main"
-  when: ansible_distribution == 'Ubuntu' and ansible_distribution_release in ('bionic', 'xenial', 'precise', 'focal')
+  when: ansible_distribution == 'Ubuntu' and ansible_distribution_release in ('bionic', 'xenial', 'precise', 'focal', 'jammy')
 
   # There are no packages for any of the non LTS versions so good
   # luck and have fun if that's you.
@@ -31,7 +31,7 @@
     filename: "cernvm.list"
     mode: 422
     repo: "deb [allow-insecure=true] https://cvmrepo.web.cern.ch/cvmrepo/apt/ xenial-prod main"
-  when: ansible_distribution == 'Ubuntu' and ansible_distribution_release not in ('bionic', 'xenial', 'precise', 'focal')
+  when: ansible_distribution == 'Ubuntu' and ansible_distribution_release not in ('bionic', 'xenial', 'precise', 'focal', 'jammy')
 
 - name: Install CernVM-FS packages and dependencies (apt)
   apt:


### PR DESCRIPTION
Official packages for jammy are available, see:
https://cvmrepo.web.cern.ch/cvmrepo/apt/dists/jammy-prod/