### PR TITLE
Use new S3-based mirror for CernVM packages

### DIFF
--- a/tasks/client.yml
+++ b/tasks/client.yml
@@ -123,7 +123,7 @@
 
 - name: Download cvmfs_preload utility when desired
   get_url:
-    url: https://cvmrepo.web.cern.ch/cvmrepo/preload/cvmfs_preload
+    url: https://cvmrepo.s3.cern.ch/cvmrepo/preload/cvmfs_preload
     dest: "{{ cvmfs_preload_path }}/cvmfs_preload"
     owner: root
     group: root

--- a/tasks/init_debian.yml
+++ b/tasks/init_debian.yml
@@ -8,20 +8,20 @@
 
 - name: Install CernVM apt key
   apt_key:
-    url: https://cvmrepo.web.cern.ch/cvmrepo/apt/cernvm.gpg
+    url: https://cvmrepo.s3.cern.ch/cvmrepo/apt/cernvm.gpg
 
 - name: Configure CernVM apt repository
   apt_repository:
     filename: "cernvm.list"
     mode: 422
-    repo: "deb [allow-insecure=true] https://cvmrepo.web.cern.ch/cvmrepo/apt/ {{ ansible_distribution_release }}-prod main"
+    repo: "deb [allow-insecure=true] https://cvmrepo.s3.cern.ch/cvmrepo/apt/ {{ ansible_distribution_release }}-prod main"
   when: ansible_distribution != 'Ubuntu'
 
 - name: Configure CernVM apt repository
   apt_repository:
     filename: "cernvm.list"
     mode: 422
-    repo: "deb [allow-insecure=true] https://cvmrepo.web.cern.ch/cvmrepo/apt/ {{ ansible_distribution_release }}-prod main"
+    repo: "deb [allow-insecure=true] https://cvmrepo.s3.cern.ch/cvmrepo/apt/ {{ ansible_distribution_release }}-prod main"
   when: ansible_distribution == 'Ubuntu' and ansible_distribution_release in ('bionic', 'xenial', 'precise', 'focal')
 
   # There are no packages for any of the non LTS versions so good
@@ -30,7 +30,7 @@
   apt_repository:
     filename: "cernvm.list"
     mode: 422
-    repo: "deb [allow-insecure=true] https://cvmrepo.web.cern.ch/cvmrepo/apt/ xenial-prod main"
+    repo: "deb [allow-insecure=true] https://cvmrepo.s3.cern.ch/cvmrepo/apt/ xenial-prod main"
   when: ansible_distribution == 'Ubuntu' and ansible_distribution_release not in ('bionic', 'xenial', 'precise', 'focal')
 
 - name: Install CernVM-FS packages and dependencies (apt)

--- a/tasks/init_redhat.yml
+++ b/tasks/init_redhat.yml
@@ -15,10 +15,10 @@
   with_items:
     - name: cernvm
       description: "CernVM packages"
-      baseurl: "http://cvmrepo.web.cern.ch/cvmrepo/yum/cvmfs/EL/$releasever/$basearch/"
+      baseurl: "http://cvmrepo.s3.cern.ch/cvmrepo/yum/cvmfs/EL/$releasever/$basearch/"
     - name: cernvm-config
       description: "CernVM-FS extra config packages"
-      baseurl: "http://cvmrepo.web.cern.ch/cvmrepo/yum/cvmfs-config/EL/$releasever/$basearch/"
+      baseurl: "http://cvmrepo.s3.cern.ch/cvmrepo/yum/cvmfs-config/EL/$releasever/$basearch/"
 
 - name: Install CernVM yum key
   copy:


### PR DESCRIPTION
See https://github.com/cvmfs/cvmfs/pull/2994 and this message on the CernVM Mattermost:

> Jakob Blomer [1:37 PM](https://mattermost.web.cern.ch/cernvm/pl/3xiqfcrr47yt7xhfsf4w13kjuc)
> We have a new package repository base URL, which should give better performance and stability.  The old one is kept in sync, too, but might be worth switching: https://cvmrepo.s3.cern.ch/cvmrepo/

I wasn't completely sure, but I guess the CernVM yum key in `tasks/init_redhat.yml` has to be modified as well to match the contents of https://cvmrepo.s3.cern.ch/cvmrepo/yum/RPM-GPG-KEY-CernVM? (the current one also differs from the one from the old mirror: https://cvmrepo.web.cern.ch/cvmrepo/yum/RPM-GPG-KEY-CernVM).