### PR TITLE
Add public key for singularity.galaxyproject.org repository

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -170,6 +170,17 @@ galaxy_cvmfs_keys:
       mAG1ceyBFowj/r3iJTa+Jcif2uAmZxg+cHkZG5KzATykF82UH1ojUzREMMDcPJi2
       dQIDAQAB
       -----END PUBLIC KEY-----
+  - path: /etc/cvmfs/keys/galaxyproject.org/singularity.galaxyproject.org.pub
+    key: |
+      -----BEGIN PUBLIC KEY-----
+      MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAuJZTWTY3/dBfspFKifv8
+      TWuuT2Zzoo1cAskKpKu5gsUAyDFbZfYBEy91qbLPC3TuUm2zdPNsjCQbbq1Liufk
+      uNPZJ8Ubn5PR6kndwrdD13NVHZpXVml1+ooTSF5CL3x/KUkYiyRz94sAr9trVoSx
+      THW2buV7ADUYivX7ofCvBu5T6YngbPZNIxDB4mh7cEal/UDtxV683A/5RL4wIYvt
+      S5SVemmu6Yb8GkGwLGmMVLYXutuaHdMFyKzWm+qFlG5JRz4okUWERvtJ2QAJPOzL
+      mAG1ceyBFowj/r3iJTa+Jcif2uAmZxg+cHkZG5KzATykF82UH1ojUzREMMDcPJi2
+      dQIDAQAB
+      -----END PUBLIC KEY-----      
   - path: /etc/cvmfs/keys/galaxyproject.org/test.galaxyproject.org.pub
     key: |
       -----BEGIN PUBLIC KEY-----


### PR DESCRIPTION
It is the same key used for galaxyproject.org, but it must be repeated because the file /etc/cvmfs/keys/galaxyproject.org/singularity.galaxyproject.org.pub needs to exist.