### PR TITLE
Fix typos notifying handlers

### DIFF
--- a/tasks/localproxy.yml
+++ b/tasks/localproxy.yml
@@ -17,7 +17,7 @@
 #       {{ inventory_hostname }} 127.0.0.1
 #     dest: /etc/squid/hosts
 #   notify:
-#     - restart squid
+#     - Restart squid
 
 - name: Include firewall tasks
   ansible.builtin.include_tasks: firewall.yml

--- a/tasks/squid.yml
+++ b/tasks/squid.yml
@@ -6,7 +6,7 @@
     backup: true
     mode: 0644
   notify:
-    - restart squid
+    - Restart squid
 
 - name: Fix cache directory permission
   ansible.builtin.file:

--- a/tasks/stratum0.yml
+++ b/tasks/stratum0.yml
@@ -46,7 +46,7 @@
     creates: /srv/cvmfs/{{ item.repository }}
   with_items: "{{ cvmfs_repositories }}"
   notify:
-    - restart apache
+    - Restart apache
 
 - name: Ensure repositories are imported
   ansible.builtin.command: |
@@ -55,7 +55,7 @@
     creates: /etc/cvmfs/repositories.d/{{ item.repository }}
   with_items: "{{ cvmfs_repositories }}"
   notify:
-    - restart apache
+    - Restart apache
 
 - name: Include repository server options tasks
   ansible.builtin.include_tasks: options.yml

--- a/tasks/stratum1.yml
+++ b/tasks/stratum1.yml
@@ -16,7 +16,7 @@
     backup: true
   when: cvmfs_config_apache
   notify:
-    - reload apache
+    - Reload apache
 
 - name: Include stratumN tasks
   ansible.builtin.include_tasks: stratumN.yml
@@ -53,7 +53,7 @@
   loop: "{{ cvmfs_repositories }}"
   register: __cvmfs_add_replica_result
   notify:
-    - restart apache
+    - Restart apache
 
 # Ideally we could use item.stratum0_url_scheme directly in `cvmfs_server add-replica` above, but it appears not to
 # support it, so we instead have to change it after the fact


### PR DESCRIPTION
As far as I know, handler names are case-sensitive.