### PR TITLE
uncomment cache_dir line in squid.conf template

### DIFF
--- a/templates/localproxy_squid.conf.j2
+++ b/templates/localproxy_squid.conf.j2
@@ -7,9 +7,9 @@ http_access allow all
 
 always_direct allow all
 
-# {% if cvmfs_localproxy_cache_dir is defined %}
-# cache_dir ufs {{ cvmfs_localproxy_cache_dir.dir }} {{ cvmfs_localproxy_cache_dir.size }} 16 256
-# {% endif %}
+{% if cvmfs_localproxy_cache_dir is defined %}
+cache_dir ufs {{ cvmfs_localproxy_cache_dir.dir }} {{ cvmfs_localproxy_cache_dir.size }} 16 256
+{% endif %}
 
 cache_mem {{ cvmfs_localproxy_cache_mem }} MB
 


### PR DESCRIPTION
I tried to setup a localproxy squid server with this role but after some debugging I realised that cvmfs_localproxy_cache_dir doesn't do anything at this moment since it's commented out in the config template.

This variable is only used for this config and there is already a conditional to leave the line out of the config if not defined so I think it's safe to uncomment. It works for me on our machines when I do.