### PR TITLE
Ensure `CVMFS_GEO_ACCOUNT_ID` is also set when a GeoIP key is provided

### DIFF
--- a/tasks/stratum1.yml
+++ b/tasks/stratum1.yml
@@ -38,6 +38,7 @@
 - name: Install GeoIP API key
   ansible.builtin.copy:
     content: |
+      CVMFS_GEO_ACCOUNT_ID="{{ cvmfs_geo_account_id }}"
       CVMFS_GEO_LICENSE_KEY="{{ cvmfs_geo_license_key }}"
     mode: 0400
     dest: /etc/cvmfs/server.local


### PR DESCRIPTION
Apparently this became required at some point? Maybe it always was and I never noticed due to previously having added it to the config after the replica was already configured? Either way, `cvmfs_server add-replica` fails without it if a key is provided.