### PR TITLE
Support running Stratum 1 without Squid

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,8 +18,10 @@ cvmfs_stratum1_http_ports:
 cvmfs_localproxy_http_ports:
   - 3128
 
-cvmfs_stratum1_apache_port: 8008
+cvmfs_stratum1_apache_port: "{{ cvmfs_stratum1_squid_enabled | ternary(8008, 80) }}"
 cvmfs_stratum1_cache_mem: 128 # MB
+
+cvmfs_stratum1_squid_enabled: true
 
 # Stratum 1 snapshot cron job timing, hash keys correspond to the cron module options:
 #   https://docs.ansible.com/ansible/latest/collections/ansible/builtin/cron_module.html

--- a/tasks/stratum1.yml
+++ b/tasks/stratum1.yml
@@ -28,6 +28,7 @@
   ansible.builtin.include_tasks: squid.yml
   vars:
     _cvmfs_squid_conf_src: "{{ cvmfs_squid_conf_src | default('stratum1_squid.conf.j2') }}"
+  when: cvmfs_stratum1_squid_enabled
 
 - name: Include firewall tasks
   ansible.builtin.include_tasks: firewall.yml


### PR DESCRIPTION
Likely a very niche case but Squid won't start on port 80 on a weird virtualization environment I have to run on one of my Stratum 1s, while httpd is fine.

I actually don't fully understand what Squid really gets you on a Stratum 1 since [the docs](https://cvmfs.readthedocs.io/en/stable/cpt-replica.html) have this to say:

> Squid should be used as a frontend to Apache, configured as a reverse proxy. It is recommended to run it on the same machine as Apache instead of a separate machine, to reduce the number of points of failure. In that case caching can be disabled for the data (since there’s no need to store it again on the same disk), but caching is helpful for the responses to geo api calls. Using a squid is also helpful for participating in shared monitoring such as the [WLCG Squid Monitor](http://wlcg-squid-monitor.cern.ch/).

I'm not sure how taxing geo api calls are but that would seem to be the only benefit for us, and perhaps could be supported directly in Apache with [`mod_cache`](https://httpd.apache.org/docs/2.4/en/mod/mod_cache.html) if needed.