### PR TITLE
Replace community.general.system.filesystem with community.general.filesystem

### DIFF
--- a/tasks/stratumN.yml
+++ b/tasks/stratumN.yml
@@ -1,6 +1,6 @@
 ---
 - name: Create /srv filesystem
-  community.general.system.filesystem:
+  community.general.filesystem:
     dev: "{{ cvmfs_srv_device }}"
     force: false
     fstype: "{{ cvmfs_srv_fstype | default('ext4') }}"


### PR DESCRIPTION
I am not sure where `community.general.system.filesystem` came from, it doesn't appear to be an old name? I am also not sure how it worked in the past.