### PR TITLE
Update the optional PolicyKit rule

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -124,6 +124,19 @@ cvmfs_geoip_db_update_day: "{{ 28 | random(seed=inventory_hostname) }}"
 #   3. this points to a cert bundle that contains CA certs for your Stratum 0 (the default here is valid for EL).
 # cvmfs_x509_cert_bundle: /etc/pki/tls/cert.pem
 
+# The role will deploy a PolicyKit rule that allows unprivileged users to manage the services in cvmfs_manage_units if
+# either of the following two options are set.
+
+# Either a list of usernames, or set to a boolean true to automatically use the 'owner's in cvmfs_repositories
+#cvmfs_manage_units_users: ...
+
+# A group name
+#cvmfs_manage_units_group: ...
+
+# The list of units that can be managed by users in the above group
+cvmfs_manage_units:
+  - squid.service
+
 #
 # Galaxy-specific stuff follows
 #

--- a/tasks/stratum1.yml
+++ b/tasks/stratum1.yml
@@ -129,4 +129,4 @@
     src: 01-manage-units.rules.j2
     dest: /etc/polkit-1/rules.d/01-manage-units.rules
     mode: 0644
-  when: cvmfs_manage_units_group is defined
+  when: cvmfs_manage_units_users is defined or cvmfs_manage_units_group is defined

--- a/templates/01-manage-units.rules.j2
+++ b/templates/01-manage-units.rules.j2
@@ -2,14 +2,23 @@
  * This file is managed by Ansible.  ALL CHANGES WILL BE OVERWRITTEN.
  */
 
-/* Allow users in the docker group to manage units. Way more control than we
- * would like to give, but the "unit" and "verb" action variables (used with
- * action.lookup()) were not added to systemd until 226, so unless RedHat
- * backports them, we are SOL.
- */
+// Allow CVMFS repo owners to manage related services
 polkit.addRule(function(action, subject) {
+    var allowedUnits = {{ cvmfs_manage_units | to_json }};
+{% if cvmfs_manage_units_users is defined and cvmfs_manage_units_users is true %}
+    var allowedUsers = {{ cvmfs_repositories | map(attribute='owner') | unique | to_json }};
+{% elif cvmfs_manage_units_users is defined %}
+    var allowedUsers = {{ cvmfs_manage_units_users | to_json }};
+{% endif %}
     if (action.id == "org.freedesktop.systemd1.manage-units" &&
+        allowedUnits.includes(action.lookup("unit")) &&
+{% if cvmfs_manage_units_users is defined and cvmfs_manage_units_group is defined %}
+        (allowedUsers.includes(subject.user) || subject.isInGroup("{{ cvmfs_manage_units_group }}"))) {
+{% elif cvmfs_manage_units_users is defined %}
+        allowedUsers.includes(subject.user)) {
+{% elif cvmfs_manage_units_group is defined %}
         subject.isInGroup("{{ cvmfs_manage_units_group }}")) {
+{% endif %}
         return polkit.Result.YES;
     }
 });


### PR DESCRIPTION
1. To limit by service
2. To take a list of users in addition to a group
2. To optionally automatically use the `owner`s in `cvmfs_repositories` instead of a provided list