### PR TITLE
Include a client playbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,19 @@ None.
 Example Playbook
 ----------------
 
-Configure all hosts as CVMFS clients with configurations for the Galaxy CVMFS repositories:
+## Configure a client
+
+There is a sample playbook in `client_playbook.yml` that can be used to
+configure a CVMFS client for Galaxy's CVMFS repositories. Note that this role
+does not currently work on Ubuntu 24.04. To use, update the inventory file in
+`inventory/clients.ini` to include the hosts you want to configure and run the
+playbook with:
+
+```sh
+ansible-playbook -i inventory/clients.ini client_playbook.yml
+```
+
+Alternatively, create your own playbook file and reference the role:
 
 ```yaml
 - name: CVMFS
@@ -151,6 +163,8 @@ Configure all hosts as CVMFS clients with configurations for the Galaxy CVMFS re
     - geerlingguy.repo-epel
     - galaxyproject.cvmfs
 ```
+
+## Configure a Stratum 1 (mirror) server
 
 Create a Stratum 1 (mirror) of the Galaxy CVMFS repositories and configure clients to prefer your Stratum 1 (assuming
 you have configured hosts in groups `cvmfsclients` and `cvmfsstratum1servers`):
@@ -174,6 +188,8 @@ you have configured hosts in groups `cvmfsclients` and `cvmfsstratum1servers`):
   roles:
     - galaxyproject.cvmfs
 ```
+
+## Configure a Stratum 0 (release manager) server
 
 Create your own CVMFS infrastructure. Run once without keys (new keys will be generated on repo creation):
 

--- a/client_playbook.yml
+++ b/client_playbook.yml
@@ -1,0 +1,10 @@
+---
+- name: Install CVMFS Client
+  hosts: cvmfs_clients
+  vars:
+    cvmfs_role: client
+    galaxy_cvmfs_repos_enabled: config-repo
+    cvmfs_quota_limit: 100
+
+  roles:
+    - .

--- a/inventory/clients.ini
+++ b/inventory/clients.ini
@@ -1,0 +1,8 @@
+[cvmfs_clients]
+cvmfs1 ansible_host=44.220.170.126
+
+[all:vars]
+ansible_user='ubuntu'
+ansible_become='yes'
+ansible_ssh_extra_args='-o StrictHostKeyChecking=no'
+ansible_ssh_private_key_file=/path/to/your/private/key.pem


### PR DESCRIPTION
I get that a playbook perhaps does not belong in the role repo and the documentation in the readme alone is enough but it including it does make for an easier setup for users...