### PR TITLE
Add noble to ubuntu releases

### DIFF
--- a/tasks/init_debian.yml
+++ b/tasks/init_debian.yml
@@ -21,7 +21,7 @@
     filename: cernvm.list
     mode: 422
     repo: deb [allow-insecure=true] https://cvmrepo.web.cern.ch/cvmrepo/apt/ {{ ansible_distribution_release }}-prod main
-  when: ansible_distribution == 'Ubuntu' and ansible_distribution_release in ('bionic', 'xenial', 'precise', 'focal', 'jammy')
+  when: ansible_distribution == 'Ubuntu' and ansible_distribution_release in ('bionic', 'xenial', 'precise', 'focal', 'jammy', 'noble')
 
 # There are no packages for any of the non LTS versions so good
 # luck and have fun if that's you.
@@ -30,7 +30,7 @@
     filename: cernvm.list
     mode: 422
     repo: deb [allow-insecure=true] https://cvmrepo.web.cern.ch/cvmrepo/apt/ xenial-prod main
-  when: ansible_distribution == 'Ubuntu' and ansible_distribution_release not in ('bionic', 'xenial', 'precise', 'focal', 'jammy')
+  when: ansible_distribution == 'Ubuntu' and ansible_distribution_release not in ('bionic', 'xenial', 'precise', 'focal', 'jammy', 'noble')
 
 - name: Install CernVM-FS packages and dependencies (apt)
   ansible.builtin.apt:


### PR DESCRIPTION
Fixes #73

Previously, packages from xenial were installed for 24.04, which caused the fuse3 error. I've tested the fix on 24.04.1 LTS.