### PR TITLE
Change Apache listen port in ports.conf for Debian

### DIFF
--- a/vars/debian.yml
+++ b/vars/debian.yml
@@ -1,6 +1,6 @@
 ---
 cvmfs_apache_service_name: apache2
-cvmfs_apache_conf_file: /etc/apache2/apache2.conf
+cvmfs_apache_conf_file: /etc/apache2/ports.conf
 
 cvmfs_squid_service_name: squid
 cvmfs_squid_conf_file: /etc/squid/squid.conf


### PR DESCRIPTION
The Listen configuration is in /etc/apache2/ports.conf in Debian-based systems. From what I can tell, this has been true at least since Debian 4.0 (Etch).

Without this change, the Listen configuration is as below on a Debian host:
```
cvmfs-s1:~$ grep -r Listen /etc/apache2/
/etc/apache2/ports.conf:Listen 80
/etc/apache2/ports.conf:	Listen 443
/etc/apache2/ports.conf:	Listen 443
/etc/apache2/apache2.conf:Listen 8008
```

For every reboot there is a race between squid and apache2 to get listening on port 80.. That's not an issue when apache2 starts first, however this breaks the Stratum 1 when squid starts first.

When apache2 starts first, squid fails to start.
```
cvmfs-s1:~$ sudo journalctl -u squid|grep commBind
Apr 08 14:18:38 cvmfs-s1-gdcm squid[1674511]: commBind Cannot bind socket FD 12 to [::]:80: (98) Address already in use
```

When squid starts first, apache2 fails to start:
```
cvmfs-s1:~$ sudo journalctl -u apache2 | grep 'could not bind to'
Apr 13 11:33:10 cvmfs-s1-gdcm apachectl[81243]: (98)Address already in use: AH00072: make_sock: could not bind to address [::]:80
Apr 13 11:33:10 cvmfs-s1-gdcm apachectl[81243]: (98)Address already in use: AH00072: make_sock: could not bind to address 0.0.0.0:80
```