### PR TITLE
Allow unauthenticated installation

### DIFF
--- a/tasks/init_debian.yml
+++ b/tasks/init_debian.yml
@@ -36,3 +36,4 @@
   ansible.builtin.apt:
     name: "{{ cvmfs_packages[_cvmfs_role] }}"
     state: "{{ 'latest' if _cvmfs_upgrade else 'present' }}"
+    allow_unauthenticated: true


### PR DESCRIPTION
Allow unauthenticated installation of CernVM-FS packages and dependencies. Otherwise it generates an error on Ubuntu Noble (see https://github.com/galaxyproject/ansible-cvmfs/issues/78).