### PR TITLE
Don't support apt-key Debian distros

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -50,6 +50,11 @@ cvmfs_stratum0_prune_snapshots_count: 50
 cvmfs_upgrade_client: false
 cvmfs_upgrade_server: false
 
+# There are no packages for any of the non-LTS Ubuntu versions or Debian sid, so if you want to use this role on one of
+# those distributions, you will need to set cvmfs_apt_distribution to one of the supported distributions and hope for
+# the best
+#cvmfs_apt_distribution: noble
+
 # Install a setuid binary allowing unprivileged users to call `cvmfs_config wipecache` or `cvmfs_talk remount sync`?
 cvmfs_install_setuid_cvmfs_wipecache: false
 cvmfs_install_setuid_cvmfs_remount_sync: false

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -38,11 +38,19 @@ galaxy_info:
   platforms:
     - name: EL
       versions:
-        - all
+        - 8
+        - 9
+        - 10
     - name: Ubuntu
       versions:
-        - all
-
+        - focal
+        - jammy
+        - noble
+    - name: Debian
+      versions:
+        - bullseye
+        - bookworm
+        - trixie
   galaxy_tags:
     - system
     - filesystem

--- a/tasks/init_debian.yml
+++ b/tasks/init_debian.yml
@@ -1,64 +1,48 @@
 ---
+
+- name: Ensure distribution is LTS or cvmfs_apt_distribution is set
+  assert:
+    that: >-
+      (ansible_distribution == 'Ubuntu' and 'LTS' in (ansible_lsb.distribution | default(''))) or
+      (ansible_distribution == 'Debian' and ansible_distribution_version != 'n/a') or
+      (cvmfs_apt_distribution is defined)
+    fail_msg: "Unsupported distribution: {{ ansible_distribution }} {{ ansible_distribution_release }}, please set cvmfs_apt_distribution"
+    success_msg: "Distribution OK"
+
 - name: Install apt dependencies
   ansible.builtin.apt:
     name:
       - apt-transport-https
       - ca-certificates
 
+- name: Remove old CernVM apt repository
+  ansible.builtin.file:
+    path: /etc/apt/sources.list.d/cernvm.list.list
+    state: absent
+
 - name: Remove old CernVM GPG key from legacy keyring
   ansible.builtin.apt_key:
     url: https://cvmrepo.web.cern.ch/cvmrepo/apt/cernvm.gpg
     state: absent
   ignore_errors: true
-  when: ansible_distribution == 'Ubuntu' and ansible_distribution_release in ('jammy', 'noble')
 
 - name: Download CernVM GPG key
   ansible.builtin.get_url:
     url: https://cvmrepo.web.cern.ch/cvmrepo/apt/cernvm.gpg
     dest: /usr/share/keyrings/cernvm.gpg
-    mode: '0644'
-  when: ansible_distribution == 'Ubuntu' and ansible_distribution_release in ('jammy', 'noble')
+    mode: "0644"
 
-- name: Configure CernVM apt repository for non-Ubuntu distributions
+- name: Configure CernVM apt repository
   ansible.builtin.apt_repository:
     filename: cernvm
-    mode: 422
-    repo: deb [signed-by=/usr/share/keyrings/cernvm.gpg] https://cvmrepo.web.cern.ch/cvmrepo/apt/ {{ ansible_distribution_release }}-prod main
-  when: ansible_distribution != 'Ubuntu'
-
-- name: Configure CernVM apt repository for older Ubuntu releases
-  ansible.builtin.apt_repository:
-    filename: cernvm.list
-    mode: 422
-    repo: deb [allow-insecure=true] https://cvmrepo.web.cern.ch/cvmrepo/apt/ {{ ansible_distribution_release }}-prod main
-  when: ansible_distribution == 'Ubuntu' and ansible_distribution_release in ('bionic', 'xenial', 'precise', 'focal')
-
-- name: Remove old CernVM apt repository (legacy format)
-  ansible.builtin.apt_repository:
-    filename: cernvm.list
-    repo: deb [allow-insecure=true] https://cvmrepo.web.cern.ch/cvmrepo/apt/ {{ ansible_distribution_release }}-prod main
-    state: absent
-  when: ansible_distribution == 'Ubuntu' and ansible_distribution_release in ('jammy', 'noble')
-
-- name: Configure CernVM apt repository for modern Ubuntu releases
-  ansible.builtin.apt_repository:
-    filename: cernvm
-    mode: 422
-    repo: deb [signed-by=/usr/share/keyrings/cernvm.gpg] https://cvmrepo.web.cern.ch/cvmrepo/apt/ {{ ansible_distribution_release }}-prod main
-  when: ansible_distribution == 'Ubuntu' and ansible_distribution_release in ('jammy', 'noble')
-
-# There are no packages for any of the non LTS versions so good
-# luck and have fun if that's you.
-- name: Configure CernVM apt repository for non-LTS Ubuntu releases
-  ansible.builtin.apt_repository:
-    filename: cernvm
-    mode: 422
-    repo: deb [signed-by=/usr/share/keyrings/cernvm.gpg] https://cvmrepo.web.cern.ch/cvmrepo/apt/ xenial-prod main
-  when: ansible_distribution == 'Ubuntu' and ansible_distribution_release not in ('bionic', 'xenial', 'precise', 'focal', 'jammy', 'noble')
+    mode: "0644"
+    repo: deb [signed-by=/usr/share/keyrings/cernvm.gpg] https://cvmrepo.web.cern.ch/cvmrepo/apt/ {{ cvmfs_apt_distribution | default(ansible_distribution_release) }}-prod main
+  register: __cvmfs_apt_respository_result
 
 - name: Update apt cache after key changes
   ansible.builtin.apt:
     update_cache: yes
+  when: __cvmfs_apt_respository_result is changed
 
 - name: Install CernVM-FS packages and dependencies (apt)
   ansible.builtin.apt:


### PR DESCRIPTION
From what I can tell, apt-key was deprecated and the new method has been supported since Debian 11 and Ubuntu 22.04. Since no older releases of either are still supported I don't think there's a reason the role needs to handle that old case. As written the tasks didn't work for me on Debian 13, since the key download only occurred on Jammy and Noble.

So this removes most of that and just configures using the new supported method, while keeping the bits that unconfigure the old method. Plus, make the user responsible for specifying which distro they want to install packages for if they're not on a supported release.