### PR TITLE
mv quota_limit and cache_base to cvmfs_param

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,8 +7,6 @@ cvmfs_server_urls: []
 cvmfs_repositories: []
 cvmfs_http_proxies:
   - DIRECT
-cvmfs_quota_limit: 4000
-cvmfs_cache_base: "/var/lib/cvmfs"
 
 cvmfs_manage_firewall: false
 
@@ -287,6 +285,8 @@ cvmfs_influx_extra_fields: ""
 # allowed parameters are documented at
 # https://cvmfs.readthedocs.io/en/stable/apx-parameters.html
 cvmfs_params: {}
+  # CVMFS_QUOTA_LIMIT: 4000
+  # CVMFS_CACHE_BASE: "/var/lib/cvmfs"
   # CVMFS_FOLLOW_REDIRECTS: true
   # CVMFS_TIMEOUT: 10
   # ...

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,6 +7,8 @@ cvmfs_server_urls: []
 cvmfs_repositories: []
 cvmfs_http_proxies:
   - DIRECT
+cvmfs_quota_limit: 4000
+cvmfs_cache_base: "/var/lib/cvmfs"
 
 cvmfs_manage_firewall: false
 
@@ -285,8 +287,6 @@ cvmfs_influx_extra_fields: ""
 # allowed parameters are documented at
 # https://cvmfs.readthedocs.io/en/stable/apx-parameters.html
 cvmfs_params: {}
-  # CVMFS_QUOTA_LIMIT: 4000
-  # CVMFS_CACHE_BASE: "/var/lib/cvmfs"
   # CVMFS_FOLLOW_REDIRECTS: true
   # CVMFS_TIMEOUT: 10
   # ...

--- a/templates/default.local.j2
+++ b/templates/default.local.j2
@@ -4,6 +4,8 @@
 
 CVMFS_REPOSITORIES="{%- for repo in cvmfs_repositories -%}{{ ',' if loop.index0 > 0 else '' }}{{ repo.repository }}{%- endfor -%}"
 CVMFS_HTTP_PROXY="{{ cvmfs_http_proxies | join(';') }}"
+{% if cvmfs_quota_limit %}CVMFS_QUOTA_LIMIT="{{ cvmfs_quota_limit }}"{% endif %}
+{% if cvmfs_cache_base %}CVMFS_CACHE_BASE="{{ cvmfs_cache_base }}"{% endif %}
 
 {% if cvmfs_telemetry %}
 CVMFS_TELEMETRY_SEND="ON"

--- a/templates/default.local.j2
+++ b/templates/default.local.j2
@@ -4,8 +4,6 @@
 
 CVMFS_REPOSITORIES="{%- for repo in cvmfs_repositories -%}{{ ',' if loop.index0 > 0 else '' }}{{ repo.repository }}{%- endfor -%}"
 CVMFS_HTTP_PROXY="{{ cvmfs_http_proxies | join(';') }}"
-CVMFS_QUOTA_LIMIT="{{ cvmfs_quota_limit }}"
-CVMFS_CACHE_BASE="{{ cvmfs_cache_base }}"
 
 {% if cvmfs_telemetry %}
 CVMFS_TELEMETRY_SEND="ON"


### PR DESCRIPTION
We noticed a small error in our recent additions. This will patch how default configuration values for quota limit and cache base are managed in the `main.yml` file. Instead of setting `cvmfs_quota_limit` and `cvmfs_cache_base` as top-level variables, their default values are now commented out and suggested within the `cvmfs_params` dictionary.

In this case we don't end-up with both alien cache base and quota_limit set and the default one.  
We only want the alien cache in such case.