### PR TITLE
El10 support

### DIFF
--- a/tasks/init_redhat.yml
+++ b/tasks/init_redhat.yml
@@ -60,3 +60,4 @@
   ansible.builtin.yum:
     name: "{{ cvmfs_packages[_cvmfs_role] }}"
     state: "{{ 'latest' if _cvmfs_upgrade else 'present' }}"
+    disable_gpg_check: no

--- a/tasks/init_redhat.yml
+++ b/tasks/init_redhat.yml
@@ -55,9 +55,15 @@
   ansible.builtin.rpm_key:
     state: present
     key: /etc/pki/rpm-gpg/RPM-GPG-KEY-CernVM
+  when: ansible_distribution_major_version | int < 10
+
+- name: Import CernVM GPG key into RPM
+  ansible.builtin.rpm_key:
+    state: present
+    key: /etc/pki/rpm-gpg/RPM-GPG-KEY-CernVM-2028
+  when: ansible_distribution_major_version | int >= 10
 
 - name: Install CernVM-FS packages and dependencies (yum)
   ansible.builtin.yum:
     name: "{{ cvmfs_packages[_cvmfs_role] }}"
     state: "{{ 'latest' if _cvmfs_upgrade else 'present' }}"
-    disable_gpg_check: no

--- a/tasks/init_redhat.yml
+++ b/tasks/init_redhat.yml
@@ -8,67 +8,44 @@
     - cernvm
     - cernvm-config
 
-- name: Configure CernVM yum repositories RHEL8/9
+- name: Download CernVM GPG key
+  ansible.builtin.get_url:
+    url: "{{ cernvm_key_url }}"
+    dest: /etc/pki/rpm-gpg/RPM-GPG-KEY-CernVM
+    owner: root
+    group: root
+    mode: "0644"
+    force: true
+  vars:
+    cernvm_key_url: >-
+      {{
+        'https://cvmrepo.web.cern.ch/cvmrepo/yum/RPM-GPG-KEY-CernVM-2048'
+        if ansible_distribution_major_version | int >= 10
+        else 'https://cvmrepo.web.cern.ch/cvmrepo/yum/RPM-GPG-KEY-CernVM'
+      }}
+
+- name: Configure CernVM repo
+  ansible.builtin.yum_repository:
+    file: cernvm
+    name: cernvm
+    description: CernVM packages
+    baseurl: http://cvmrepo.web.cern.ch/cvmrepo/yum/cvmfs/EL/$releasever/$basearch/
+    gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CernVM
+    gpgcheck: true
+    enabled: true
+    protect: true
+
+- name: Configure CernVM config repo
+  ansible.builtin.yum_repository:
+    file: cernvm
+    name: cernvm-config
+    description: CernVM-FS extra config packages
+    baseurl: http://cvmrepo.web.cern.ch/cvmrepo/yum/cvmfs-config/EL/$releasever/$basearch/
+    gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CernVM
+    gpgcheck: true
+    enabled: true
+    protect: true
   when: ansible_distribution_major_version | int < 10
-  block:
-    - name: Configure CernVM yum repositories
-      ansible.builtin.yum_repository:
-        file: cernvm
-        name: "{{ item.name }}"
-        description: "{{ item.description }}"
-        baseurl: "{{ item.baseurl }}"
-        gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CernVM
-        gpgcheck: true
-        enabled: true
-        protect: true
-      loop:
-        - name: cernvm
-          description: CernVM packages
-          baseurl: http://cvmrepo.web.cern.ch/cvmrepo/yum/cvmfs/EL/$releasever/$basearch/
-        - name: cernvm-config
-          description: CernVM-FS extra config packages
-          baseurl: http://cvmrepo.web.cern.ch/cvmrepo/yum/cvmfs-config/EL/$releasever/$basearch/
-
-    - name: Download CernVM GPG key
-      ansible.builtin.get_url:
-        url: https://cvmrepo.web.cern.ch/cvmrepo/yum/RPM-GPG-KEY-CernVM
-        dest: /etc/pki/rpm-gpg/RPM-GPG-KEY-CernVM
-        owner: root
-        group: root
-        mode: "0644"
-        force: true
-
-- name: Configure CernVM yum repositories RHEL10+
-  when: ansible_distribution_major_version | int >= 10
-  block:
-    - name: Configure CernVM yum repositories RHEL10+
-      ansible.builtin.yum_repository:
-        file: cernvm
-        name: "{{ item.name }}"
-        description: "{{ item.description }}"
-        baseurl: "{{ item.baseurl }}"
-        gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CernVM
-        gpgcheck: true
-        enabled: true
-        protect: true
-      loop:
-        - name: cernvm
-          description: CernVM packages
-          baseurl: http://cvmrepo.web.cern.ch/cvmrepo/yum/cvmfs/EL/$releasever/$basearch/
-
-    - name: Download CernVM GPG key (2048-bit for RHEL10+)
-      ansible.builtin.get_url:
-        url: https://cvmrepo.web.cern.ch/cvmrepo/yum/RPM-GPG-KEY-CernVM-2048
-        dest: /etc/pki/rpm-gpg/RPM-GPG-KEY-CernVM
-        owner: root
-        group: root
-        mode: "0644"
-        force: true
-
-- name: Import CernVM GPG key into RPM
-  ansible.builtin.rpm_key:
-    state: present
-    key: /etc/pki/rpm-gpg/RPM-GPG-KEY-CernVM
 
 - name: Install CernVM-FS packages and dependencies (yum)
   ansible.builtin.yum:

--- a/tasks/init_redhat.yml
+++ b/tasks/init_redhat.yml
@@ -45,7 +45,7 @@
 
 - name: Download CernVM GPG key
   ansible.builtin.get_url:
-    url: https://cvmrepo.web.cern.ch/cvmrepo/yum/RPM-GPG-KEY-CernVM-2048
+    url: https://cvmrepo.web.cern.ch/cvmrepo/yum/RPM-GPG-KEY-CernVM
     dest: /etc/pki/rpm-gpg/RPM-GPG-KEY-CernVM
     owner: root
     group: root

--- a/tasks/init_redhat.yml
+++ b/tasks/init_redhat.yml
@@ -26,43 +26,18 @@
     #   description: CernVM-FS extra config packages
     #   baseurl: http://cvmrepo.web.cern.ch/cvmrepo/yum/cvmfs-config/EL/$releasever/$basearch/
 
-- name: Install CernVM yum key
-  ansible.builtin.copy:
-    content: |
-      -----BEGIN PGP PUBLIC KEY BLOCK-----
-      Version: GnuPG v2.0.22 (GNU/Linux)
-
-      mQGiBEuGP6YRBADV89cbF4uoEX89Q8uxOklIDVJhOJAFKZ33LSdzHv3iObnjo5w4
-      wbb8FiSir4oWgarAco4u0kR1yKjHJ33oVB2xmPOzW3NWoHI7aPF7tCgo7FY9hNoC
-      4NEkNycvbfSoCScsv2yY5qz2q2sY1LWGZGbUXjBvKbmASe9sJFKJV7NsmwCg76W/
-      aMazleHyDtooD8tk3ZWvpKcD/Rg51Oad+ZLc7h45wDMHpaDvOBeGoyp+k7JgQd87
-      HfXiJtg/Q6zyTwrV3vCQvMpw3GRjRkZBcPgRWb6rUk68dL8fa2cTxhISX5/DIQzc
-      mmuDa0EgCGGAKUZ4bHqaexFFnp/B+VKBPvJuxLa0cBDd6eewxNwtHJ90EaMeBzGd
-      6zU2BADO9YbXiEMqRkfVLnuvD5G31/WJZvffXCxspnSfg923DbILWa4vNW9MLMsK
-      IVHvyVr0mZF8xdyQNVPUX3/4uahKM4hwuFqdbyjuLGEIF3U73aIJ0+YDep/+I6yU
-      JGHnxy8Ex+a1XIhJ1hSI7+oalSdt+w/pE3+2MQyUfSDPSXVA3LQ+Q2VyblZNIEFk
-      bWluaXN0cmF0b3IgKGN2bWFkbWluKSA8Y2VybnZtLmFkbWluaXN0cmF0b3JAY2Vy
-      bi5jaD6IXgQTEQIAHgIbAwYLCQgHAwIDFQIDAxYCAQIeAQIXgAUCVwOYkgAKCRAj
-      DTidiuRc50E1AJ9AYvH/cydD7029jxGcs8K87lo3jACdEhbCj3cjPsp2U/WfpgK1
-      BQOMiwe5Ag0ES4Y/qBAIAL3sWKXQKpbIOpwX+mNX2IV2XxNBM3KYjYOEii66i9ap
-      Po3BA39a9Wm9vh1kYIHTkh9Qqb8w53hc4ANkVT+cYzxXythGBjWoLtwCzKCPrIb7
-      RQJRc956Ot0q4qmlcUEGi5zefSIoJZR5jyR7rZS+1PNJYI05xY2+Eah1u9UxrlzB
-      H5DCsvUqTNK12WrPIibmLo8u+yIDJjwgh9O5YITC+et/g47NLfZdiAGPLEjvJFRi
-      7Ju+8ywO32dSVBPJQDktr5BC950DKZHA9n+sJ63iF3lP/aCTECpxxUqXVVqioobw
-      g5ytl60hw9I9sfwBP6z9PR90RcyT1l4giiBz9LV+KpcAAwUIAKeAxArGaJxzWziK
-      s7D8TTuE50Nw+S3RGhVzwSKy7183Z11iOEMqbm2/zwp65wFkntCKmLKDnGsTgFNp
-      stIyFwJmj34Axp7N3KGqXnTI+SIQd6VmzQ1phxfCOw8IGueOR6YI7S1GYWt7Dose
-      ZKz4EWdvXCOkQAhbxq/HT2c3ihxsuxrErxz7QtNaYOFXiuLj3mYH9XaMeEe8Pkl+
-      yyRTvyUNlMIu/i79qf+QUlsi10nCUm88cSXQiKWOJ4GiUoT+jD7pN4ohdALRVl0t
-      l/EyPTw+asG3lQhPZ+solvJXp+i7KF7nwnyXDB63WNH15S1pQLMnqCuGCFyegf6j
-      nOJU0AqISQQYEQIACQIbDAUCVwOYgwAKCRAjDTidiuRc534jAKDu/9BZU3rirEMr
-      DuGbmN3ulUM+UgCfe7lg5qrGXUzZlJFTnTaTgS3Z0Rg=
-      =fspm
-      -----END PGP PUBLIC KEY BLOCK-----
+- name: Download CernVM GPG key
+  ansible.builtin.get_url:
+    url: https://cvmrepo.web.cern.ch/cvmrepo/yum/RPM-GPG-KEY-CernVM-2048
     dest: /etc/pki/rpm-gpg/RPM-GPG-KEY-CernVM
     owner: root
     group: root
     mode: "0644"
+
+- name: Import CernVM GPG key into RPM
+  ansible.builtin.rpm_key:
+    state: present
+    key: /etc/pki/rpm-gpg/RPM-GPG-KEY-CernVM
 
 - name: Install CernVM-FS packages and dependencies (yum)
   ansible.builtin.yum:

--- a/tasks/init_redhat.yml
+++ b/tasks/init_redhat.yml
@@ -35,18 +35,6 @@
     enabled: true
     protect: true
 
-- name: Configure CernVM config repo
-  ansible.builtin.yum_repository:
-    file: cernvm
-    name: cernvm-config
-    description: CernVM-FS extra config packages
-    baseurl: http://cvmrepo.web.cern.ch/cvmrepo/yum/cvmfs-config/EL/$releasever/$basearch/
-    gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CernVM
-    gpgcheck: true
-    enabled: true
-    protect: true
-  when: ansible_distribution_major_version | int < 10
-
 - name: Install CernVM-FS packages and dependencies (yum)
   ansible.builtin.yum:
     name: "{{ cvmfs_packages[_cvmfs_role] }}"

--- a/tasks/init_redhat.yml
+++ b/tasks/init_redhat.yml
@@ -8,60 +8,67 @@
     - cernvm
     - cernvm-config
 
-- name: Configure CernVM yum repositories
-  ansible.builtin.yum_repository:
-    file: cernvm
-    name: "{{ item.name }}"
-    description: "{{ item.description }}"
-    baseurl: "{{ item.baseurl }}"
-    gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CernVM
-    gpgcheck: true
-    enabled: true
-    protect: true
-  loop:
-    - name: cernvm
-      description: CernVM packages
-      baseurl: http://cvmrepo.web.cern.ch/cvmrepo/yum/cvmfs/EL/$releasever/$basearch/
-    - name: cernvm-config
-      description: CernVM-FS extra config packages
-      baseurl: http://cvmrepo.web.cern.ch/cvmrepo/yum/cvmfs-config/EL/$releasever/$basearch/
+- name: Configure CernVM yum repositories RHEL8/9
   when: ansible_distribution_major_version | int < 10
+  block:
+    - name: Configure CernVM yum repositories
+      ansible.builtin.yum_repository:
+        file: cernvm
+        name: "{{ item.name }}"
+        description: "{{ item.description }}"
+        baseurl: "{{ item.baseurl }}"
+        gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CernVM
+        gpgcheck: true
+        enabled: true
+        protect: true
+      loop:
+        - name: cernvm
+          description: CernVM packages
+          baseurl: http://cvmrepo.web.cern.ch/cvmrepo/yum/cvmfs/EL/$releasever/$basearch/
+        - name: cernvm-config
+          description: CernVM-FS extra config packages
+          baseurl: http://cvmrepo.web.cern.ch/cvmrepo/yum/cvmfs-config/EL/$releasever/$basearch/
+
+    - name: Download CernVM GPG key
+      ansible.builtin.get_url:
+        url: https://cvmrepo.web.cern.ch/cvmrepo/yum/RPM-GPG-KEY-CernVM
+        dest: /etc/pki/rpm-gpg/RPM-GPG-KEY-CernVM
+        owner: root
+        group: root
+        mode: "0644"
+        force: true
 
 - name: Configure CernVM yum repositories RHEL10+
-  ansible.builtin.yum_repository:
-    file: cernvm
-    name: "{{ item.name }}"
-    description: "{{ item.description }}"
-    baseurl: "{{ item.baseurl }}"
-    gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CernVM
-    gpgcheck: true
-    enabled: true
-    protect: true
-  loop:
-    - name: cernvm
-      description: CernVM packages
-      baseurl: http://cvmrepo.web.cern.ch/cvmrepo/yum/cvmfs/EL/$releasever/$basearch/
   when: ansible_distribution_major_version | int >= 10
+  block:
+    - name: Configure CernVM yum repositories RHEL10+
+      ansible.builtin.yum_repository:
+        file: cernvm
+        name: "{{ item.name }}"
+        description: "{{ item.description }}"
+        baseurl: "{{ item.baseurl }}"
+        gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CernVM
+        gpgcheck: true
+        enabled: true
+        protect: true
+      loop:
+        - name: cernvm
+          description: CernVM packages
+          baseurl: http://cvmrepo.web.cern.ch/cvmrepo/yum/cvmfs/EL/$releasever/$basearch/
 
-- name: Download CernVM GPG key
-  ansible.builtin.get_url:
-    url: https://cvmrepo.web.cern.ch/cvmrepo/yum/RPM-GPG-KEY-CernVM
-    dest: /etc/pki/rpm-gpg/RPM-GPG-KEY-CernVM
-    owner: root
-    group: root
-    mode: "0644"
+    - name: Download CernVM GPG key (2048-bit for RHEL10+)
+      ansible.builtin.get_url:
+        url: https://cvmrepo.web.cern.ch/cvmrepo/yum/RPM-GPG-KEY-CernVM-2048
+        dest: /etc/pki/rpm-gpg/RPM-GPG-KEY-CernVM
+        owner: root
+        group: root
+        mode: "0644"
+        force: true
 
 - name: Import CernVM GPG key into RPM
   ansible.builtin.rpm_key:
     state: present
     key: /etc/pki/rpm-gpg/RPM-GPG-KEY-CernVM
-  when: ansible_distribution_major_version | int < 10
-
-- name: Import CernVM GPG key into RPM
-  ansible.builtin.rpm_key:
-    state: present
-    key: /etc/pki/rpm-gpg/RPM-GPG-KEY-CernVM-2028
-  when: ansible_distribution_major_version | int >= 10
 
 - name: Install CernVM-FS packages and dependencies (yum)
   ansible.builtin.yum:

--- a/tasks/init_redhat.yml
+++ b/tasks/init_redhat.yml
@@ -25,7 +25,23 @@
     - name: cernvm-config
       description: CernVM-FS extra config packages
       baseurl: http://cvmrepo.web.cern.ch/cvmrepo/yum/cvmfs-config/EL/$releasever/$basearch/
-  when: item.name != 'cernvm-config' or ansible_distribution_major_version | int < 10
+  when: ansible_distribution_major_version | int < 10
+
+- name: Configure CernVM yum repositories RHEL10+
+  ansible.builtin.yum_repository:
+    file: cernvm
+    name: "{{ item.name }}"
+    description: "{{ item.description }}"
+    baseurl: "{{ item.baseurl }}"
+    gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CernVM
+    gpgcheck: true
+    enabled: true
+    protect: true
+  loop:
+    - name: cernvm
+      description: CernVM packages
+      baseurl: http://cvmrepo.web.cern.ch/cvmrepo/yum/cvmfs/EL/$releasever/$basearch/
+  when: ansible_distribution_major_version | int >= 10
 
 - name: Download CernVM GPG key
   ansible.builtin.get_url:

--- a/tasks/init_redhat.yml
+++ b/tasks/init_redhat.yml
@@ -22,9 +22,10 @@
     - name: cernvm
       description: CernVM packages
       baseurl: http://cvmrepo.web.cern.ch/cvmrepo/yum/cvmfs/EL/$releasever/$basearch/
-    # - name: cernvm-config
-    #   description: CernVM-FS extra config packages
-    #   baseurl: http://cvmrepo.web.cern.ch/cvmrepo/yum/cvmfs-config/EL/$releasever/$basearch/
+    - name: cernvm-config
+      description: CernVM-FS extra config packages
+      baseurl: http://cvmrepo.web.cern.ch/cvmrepo/yum/cvmfs-config/EL/$releasever/$basearch/
+  when: item.name != 'cernvm-config' or ansible_distribution_major_version | int < 10
 
 - name: Download CernVM GPG key
   ansible.builtin.get_url:

--- a/tasks/init_redhat.yml
+++ b/tasks/init_redhat.yml
@@ -22,15 +22,15 @@
     - name: cernvm
       description: CernVM packages
       baseurl: http://cvmrepo.web.cern.ch/cvmrepo/yum/cvmfs/EL/$releasever/$basearch/
-    - name: cernvm-config
-      description: CernVM-FS extra config packages
-      baseurl: http://cvmrepo.web.cern.ch/cvmrepo/yum/cvmfs-config/EL/$releasever/$basearch/
+    # - name: cernvm-config
+    #   description: CernVM-FS extra config packages
+    #   baseurl: http://cvmrepo.web.cern.ch/cvmrepo/yum/cvmfs-config/EL/$releasever/$basearch/
 
 - name: Install CernVM yum key
   ansible.builtin.copy:
     content: |
       -----BEGIN PGP PUBLIC KEY BLOCK-----
-      Version: GnuPG v2.0.14 (GNU/Linux)
+      Version: GnuPG v2.0.22 (GNU/Linux)
 
       mQGiBEuGP6YRBADV89cbF4uoEX89Q8uxOklIDVJhOJAFKZ33LSdzHv3iObnjo5w4
       wbb8FiSir4oWgarAco4u0kR1yKjHJ33oVB2xmPOzW3NWoHI7aPF7tCgo7FY9hNoC
@@ -42,22 +42,22 @@
       IVHvyVr0mZF8xdyQNVPUX3/4uahKM4hwuFqdbyjuLGEIF3U73aIJ0+YDep/+I6yU
       JGHnxy8Ex+a1XIhJ1hSI7+oalSdt+w/pE3+2MQyUfSDPSXVA3LQ+Q2VyblZNIEFk
       bWluaXN0cmF0b3IgKGN2bWFkbWluKSA8Y2VybnZtLmFkbWluaXN0cmF0b3JAY2Vy
-      bi5jaD6IZAQTEQIAJAIbAwYLCQgHAwIDFQIDAxYCAQIeAQIXgAUCT18LigUJBbn/
-      ZAAKCRAjDTidiuRc5/BFAKCb13G8yxG75r3s63mHo5l9PNUKGwCfZpSlZrhBsVZ4
-      2DsKfLG1VQ+X8HW5Ag0ES4Y/qBAIAL3sWKXQKpbIOpwX+mNX2IV2XxNBM3KYjYOE
-      ii66i9apPo3BA39a9Wm9vh1kYIHTkh9Qqb8w53hc4ANkVT+cYzxXythGBjWoLtwC
-      zKCPrIb7RQJRc956Ot0q4qmlcUEGi5zefSIoJZR5jyR7rZS+1PNJYI05xY2+Eah1
-      u9UxrlzBH5DCsvUqTNK12WrPIibmLo8u+yIDJjwgh9O5YITC+et/g47NLfZdiAGP
-      LEjvJFRi7Ju+8ywO32dSVBPJQDktr5BC950DKZHA9n+sJ63iF3lP/aCTECpxxUqX
-      VVqioobwg5ytl60hw9I9sfwBP6z9PR90RcyT1l4giiBz9LV+KpcAAwUIAKeAxArG
-      aJxzWziKs7D8TTuE50Nw+S3RGhVzwSKy7183Z11iOEMqbm2/zwp65wFkntCKmLKD
-      nGsTgFNpstIyFwJmj34Axp7N3KGqXnTI+SIQd6VmzQ1phxfCOw8IGueOR6YI7S1G
-      YWt7DoseZKz4EWdvXCOkQAhbxq/HT2c3ihxsuxrErxz7QtNaYOFXiuLj3mYH9XaM
-      eEe8Pkl+yyRTvyUNlMIu/i79qf+QUlsi10nCUm88cSXQiKWOJ4GiUoT+jD7pN4oh
-      dALRVl0tl/EyPTw+asG3lQhPZ+solvJXp+i7KF7nwnyXDB63WNH15S1pQLMnqCuG
-      CFyegf6jnOJU0AqITwQYEQIADwIbDAUCT18MOQUJBboAEQAKCRAjDTidiuRc53P2
-      AJ9e1y70yIKwx6YmpDnwqWSE07Q6lACdEnem0DbLg9t+gkX/98driCP9Ifg=
-      =S7Dt
+      bi5jaD6IXgQTEQIAHgIbAwYLCQgHAwIDFQIDAxYCAQIeAQIXgAUCVwOYkgAKCRAj
+      DTidiuRc50E1AJ9AYvH/cydD7029jxGcs8K87lo3jACdEhbCj3cjPsp2U/WfpgK1
+      BQOMiwe5Ag0ES4Y/qBAIAL3sWKXQKpbIOpwX+mNX2IV2XxNBM3KYjYOEii66i9ap
+      Po3BA39a9Wm9vh1kYIHTkh9Qqb8w53hc4ANkVT+cYzxXythGBjWoLtwCzKCPrIb7
+      RQJRc956Ot0q4qmlcUEGi5zefSIoJZR5jyR7rZS+1PNJYI05xY2+Eah1u9UxrlzB
+      H5DCsvUqTNK12WrPIibmLo8u+yIDJjwgh9O5YITC+et/g47NLfZdiAGPLEjvJFRi
+      7Ju+8ywO32dSVBPJQDktr5BC950DKZHA9n+sJ63iF3lP/aCTECpxxUqXVVqioobw
+      g5ytl60hw9I9sfwBP6z9PR90RcyT1l4giiBz9LV+KpcAAwUIAKeAxArGaJxzWziK
+      s7D8TTuE50Nw+S3RGhVzwSKy7183Z11iOEMqbm2/zwp65wFkntCKmLKDnGsTgFNp
+      stIyFwJmj34Axp7N3KGqXnTI+SIQd6VmzQ1phxfCOw8IGueOR6YI7S1GYWt7Dose
+      ZKz4EWdvXCOkQAhbxq/HT2c3ihxsuxrErxz7QtNaYOFXiuLj3mYH9XaMeEe8Pkl+
+      yyRTvyUNlMIu/i79qf+QUlsi10nCUm88cSXQiKWOJ4GiUoT+jD7pN4ohdALRVl0t
+      l/EyPTw+asG3lQhPZ+solvJXp+i7KF7nwnyXDB63WNH15S1pQLMnqCuGCFyegf6j
+      nOJU0AqISQQYEQIACQIbDAUCVwOYgwAKCRAjDTidiuRc534jAKDu/9BZU3rirEMr
+      DuGbmN3ulUM+UgCfe7lg5qrGXUzZlJFTnTaTgS3Z0Rg=
+      =fspm
       -----END PGP PUBLIC KEY BLOCK-----
     dest: /etc/pki/rpm-gpg/RPM-GPG-KEY-CernVM
     owner: root


### PR DESCRIPTION
This pull request refactors how the CernVM GPG key and yum repositories are configured in the `init_redhat.yml` Ansible task. The main improvement is replacing the hardcoded GPG key block with a dynamic download, and splitting the repository configuration into distinct tasks for better clarity and maintainability.

We have tested the role both for Rocky 9 and 10 and it seems to works. 