### PR TITLE
Update Galaxy repos config and drop support for Galaxy config repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,21 +25,8 @@ All variables are optional. However, if unset, the role will essentially do noth
 ## Galaxy Client
 
 Other than `cvmfs_role` as described below, [Galaxy][galaxy] administrators will most likely only need to set the
-`galaxy_cvmfs_repos_enabled` variable (disabled by default), which automatically configures the CVMFS client for
-[galaxyproject.org][galaxy] CVMFS repositories.
-
-The value of `galaxy_cvmfs_repos_enabled` can be either `config-repo` or any value that evaluates to `true` (or `false`
-to explcititly disable, although this is the default). Using `config-repo` is recommended since it causes the role to
-only install a minimal configuration needed to mount the `cvmfs-config.galaxyproject.org` CVMFS repository, and then
-uses CVMFS' [Config Repository][cvmfs-config-repo] support to obtain the configs for the other galaxyproject.org CVMFS
-repositories. This ensures you will always have up-to-date configs for all galaxyproject.org CVMFS repositories.
-
-Setting `galaxy_cvmfs_repos_enabled` to `config-repo` overrides the value of `cvmfs_config_repo` since there can be only
-one default config repo configured on the client.
-
-Setting `galaxy_cvmfs_repos_enabled` to any other truthy value will causes the role to create a static configuration
-where the full configurations for each galaxyproject.org CVMFS repository is installed on the target host. This option
-is retained for legacy purposes.
+`galaxy_cvmfs_repos_enabled` variable to `true` (`false` by default), which automatically configures the CVMFS client
+for [galaxyproject.org][galaxy] CVMFS repositories.
 
 You can override the defaults for Galaxy's `cvmfs_keys`, `cvmfs_server_urls`, and `cvmfs_repositories` by prepending
 `galaxy_` to the variable names. See the [defaults][defaults] for details.
@@ -55,7 +42,7 @@ variable | type | description
 `cvmfs_keys` | list of dicts | Keys to install on hosts of all types.
 `cvmfs_server_urls` | list of dicts | CVMFS server URLs, the value of `CVMFS_SERVER_URL` in `/etc/cvmfs/domain.d/<domain>.conf`.
 `cvmfs_repositories` | list of dicts | CVMFS repository configurations, the value of `CVMFS_REPOSITORIES` in `/etc/cvmfs/default.local` plus additional settings in `/etc/cvmfs/repositories.d/<repository>/{client,server}.conf`.
-`cvmfs_config_repo` | dict | CVMFS [Configuration Repository][cvmfs-config-repo] configuration, see the value of `galaxy_cvmfs_config_repo` in the [defaults][defaults] for syntax.
+`cvmfs_config_repo` | dict | CVMFS [Configuration Repository][cvmfs-config-repo] configuration.
 `cvmfs_quota_limit` | integer in MB | Size of CVMFS client cache. Default is `4000`.
 `cvmfs_upgrade_client` | boolean | Upgrade CVMFS on clients to the latest version if it is already installed. Default is `false`.
 `cvmfs_preload_install` | boolean | Install the `cvmfs_preload` script for [preloading the CVMFS cache][preload].
@@ -146,7 +133,7 @@ Configure all hosts as CVMFS clients with configurations for the Galaxy CVMFS re
   hosts: all
   vars:
     cvmfs_role: client
-    galaxy_cvmfs_repos_enabled: config-repo
+    galaxy_cvmfs_repos_enabled: true
   roles:
     - geerlingguy.repo-epel
     - galaxyproject.cvmfs

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -108,8 +108,28 @@ cvmfs_gc_time:
 cvmfs_preload_install: false
 cvmfs_preload_path: /usr/bin
 
-# Support for CVMFS config repositories - see galaxy_cvmfs_config_repo for syntax
+# Support for CVMFS config repositories
 cvmfs_config_repo: {}
+  # Sets the value of CVMFS_DEFAULT_DOMAIN
+  #domain: cern.ch
+  # Key of the config repo
+  #key:
+  #  path: /etc/cvmfs/keys/cern.ch/cern.ch.pub
+  #  key: |
+  #    -----BEGIN PUBLIC KEY-----
+  #    MII...
+  #    -----END PUBLIC KEY-----
+  # URLs to Stratum 1 servers (value of CVMFS_SERVER_URL, semicolon-joined)
+  #urls:
+  #  - http://cvmfs-stratum-one.cern.ch/cvmfs/@fqrn@
+  #  - ...
+  # Config repository details
+  #repository:
+  #  repository: cvmfs-config.cern.ch
+  #  owner: "{{ cvmfs_repo_owner | default('root') }}"
+  #  server_options: []
+  #  client_options: []
+
 # CVMFS_CONFIG_REPOSITORY is not supported on Debian < 9, Ubuntu LTS < 18.04
 cvmfs_config_repo_supported: >-
   {{
@@ -151,36 +171,9 @@ cvmfs_manage_units:
 # Automatically configure Galaxy CVMFS repos
 galaxy_cvmfs_repos_enabled: false
 
-# Defaults for galaxyproject.org config repo, syntax for each key is the same as that of cvmfs_<key | pluralize>
-galaxy_cvmfs_config_repo:
-  domain: galaxyproject.org
-  key:
-    path: /etc/cvmfs/keys/galaxyproject.org/cvmfs-config.galaxyproject.org.pub
-    key: |
-      -----BEGIN PUBLIC KEY-----
-      MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAuJZTWTY3/dBfspFKifv8
-      TWuuT2Zzoo1cAskKpKu5gsUAyDFbZfYBEy91qbLPC3TuUm2zdPNsjCQbbq1Liufk
-      uNPZJ8Ubn5PR6kndwrdD13NVHZpXVml1+ooTSF5CL3x/KUkYiyRz94sAr9trVoSx
-      THW2buV7ADUYivX7ofCvBu5T6YngbPZNIxDB4mh7cEal/UDtxV683A/5RL4wIYvt
-      S5SVemmu6Yb8GkGwLGmMVLYXutuaHdMFyKzWm+qFlG5JRz4okUWERvtJ2QAJPOzL
-      mAG1ceyBFowj/r3iJTa+Jcif2uAmZxg+cHkZG5KzATykF82UH1ojUzREMMDcPJi2
-      dQIDAQAB
-      -----END PUBLIC KEY-----
-  urls:
-    - http://cvmfs1-psu0.galaxyproject.org/cvmfs/@fqrn@
-    - http://cvmfs1-iu0.galaxyproject.org/cvmfs/@fqrn@
-    - http://cvmfs1-tacc0.galaxyproject.org/cvmfs/@fqrn@
-    - http://cvmfs1-ufr0.galaxyproject.eu/cvmfs/@fqrn@
-    - http://cvmfs1-mel0.gvl.org.au/cvmfs/@fqrn@
-  repository:
-    repository: cvmfs-config.galaxyproject.org
-    stratum0: cvmfs0-psu0.galaxyproject.org
-    owner: "{{ cvmfs_repo_owner | default('root') }}"
-    server_options: []
-    client_options: []
 # Defaults for galaxyproject.org repos
 galaxy_cvmfs_keys:
-  # This will become the key for all repos, currently cvmfs-config, singularity, and test
+  # This is the common key for all *.galaxyproject.org repos except data.galaxyproject.org
   - path: /etc/cvmfs/keys/galaxyproject.org/galaxyproject.org.pub
     key: |
       -----BEGIN PUBLIC KEY-----
@@ -203,21 +196,10 @@ galaxy_cvmfs_keys:
       NVNhhcb66OJHah5ppI1N3cZehdaKyr1XcF9eedwLFTvuiwTn6qMmttT/tHX7rcxT
       owIDAQAB
       -----END PUBLIC KEY-----
-  - path: /etc/cvmfs/keys/galaxyproject.org/main.galaxyproject.org.pub
-    key: |
-      -----BEGIN PUBLIC KEY-----
-      MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA6S6Tugcv4kk4C06f574l
-      YCXQdK6lv2m7mqCh60G0zL1+rAkkEBDWna0yMQLBbj+yDsHjcOe0yISzbTfzG6wk
-      KnHZUQ/JOeK7lUAbDMxHqnjkEPAbAl4vXl2Y04MW2lzJtXcDKakmLirvV/dfUYqE
-      gGGx0dc/Z+XmUTf1DvZFJknrBUUxO5+F6m7k/NGrlpAca+e9B0kwCclaE4NyaNWK
-      Jv5rPWCYz5/sDNW4cNvBdBjwGf46etbczmJoTAbl0oM6LLGdebwkJStd0R1wkj+A
-      torRYcoFZICTZqY9e/KsadHUeZnH3RvfMypH5oS1POzsFszoSxBhZIBkZbG3/f9Y
-      OQIDAQAB
-      -----END PUBLIC KEY-----
 
 galaxy_cvmfs_server_urls:
   - domain: galaxyproject.org
-    use_geoapi: false
+    use_geoapi: true
     urls:
       - http://cvmfs1-psu0.galaxyproject.org/cvmfs/@fqrn@
       - http://cvmfs1-iu0.galaxyproject.org/cvmfs/@fqrn@
@@ -230,13 +212,15 @@ galaxy_cvmfs_repositories:
     stratum0: cvmfs0-psu1.galaxyproject.org
     owner: "{{ cvmfs_repo_owner | default('root') }}"
     key_dir: /etc/cvmfs/keys/galaxyproject.org
+    key_name: galaxyproject.org
     server_options:
       - CVMFS_AUTO_GC=false
     client_options: []
   - repository: main.galaxyproject.org
-    stratum0: cvmfs0-tacc0.galaxyproject.org
+    stratum0: cvmfs0-psu1.galaxyproject.org
     owner: "{{ cvmfs_repo_owner | default('root') }}"
     key_dir: /etc/cvmfs/keys/galaxyproject.org
+    key_name: galaxyproject.org
     server_options:
       - CVMFS_AUTO_GC=false
     client_options: []
@@ -244,33 +228,41 @@ galaxy_cvmfs_repositories:
     stratum0: cvmfs0-psu0.galaxyproject.org
     owner: "{{ cvmfs_repo_owner | default('root') }}"
     key_dir: /etc/cvmfs/keys/galaxyproject.org
+    key_name: data.galaxyproject.org
     server_options:
       - CVMFS_AUTO_GC=false
-    client_options: []
-  - repository: refgenomes-databio.galaxyproject.org
-    stratum0: cvmfs0-psu0.galaxyproject.org
-    owner: "{{ cvmfs_repo_owner | default('root') }}"
-    key_dir: /etc/cvmfs/keys/galaxyproject.org
-    server_options:
-      - CVMFS_AUTO_GC=false
-    client_options: []
-  - repository: sandbox.galaxyproject.org
-    stratum0: cvmfs0-psu0.galaxyproject.org
-    owner: "{{ cvmfs_repo_owner | default('root') }}"
-    key_dir: /etc/cvmfs/keys/galaxyproject.org
-    server_options: []
     client_options: []
   - repository: singularity.galaxyproject.org
     stratum0: cvmfs-stratum0.galaxyproject.eu
     owner: "{{ cvmfs_repo_owner | default('root') }}"
     key_dir: /etc/cvmfs/keys/galaxyproject.org
-    server_options: []
+    key_name: galaxyproject.org
+    server_options:
+      - CVMFS_AUTO_GC=false
     client_options: []
-  - repository: usegalaxy.galaxyproject.org
+  - repository: idc.galaxyproject.org
     stratum0: cvmfs0-psu0.galaxyproject.org
     owner: "{{ cvmfs_repo_owner | default('root') }}"
     key_dir: /etc/cvmfs/keys/galaxyproject.org
-    server_options: []
+    key_name: galaxyproject.org
+    server_options:
+      - CVMFS_AUTO_GC=false
+    client_options: []
+  - repository: brc.galaxyproject.org
+    stratum0: cvmfs0-psu0.galaxyproject.org
+    owner: "{{ cvmfs_repo_owner | default('root') }}"
+    key_dir: /etc/cvmfs/keys/galaxyproject.org
+    key_name: galaxyproject.org
+    server_options:
+      - CVMFS_AUTO_GC=false
+    client_options: []
+  - repository: vgp.galaxyproject.org
+    stratum0: cvmfs0-psu0.galaxyproject.org
+    owner: "{{ cvmfs_repo_owner | default('root') }}"
+    key_dir: /etc/cvmfs/keys/galaxyproject.org
+    key_name: galaxyproject.org
+    server_options:
+      - CVMFS_AUTO_GC=false
     client_options: []
 
 # Only enables telemetry if cvmfs_telemetry is true

--- a/tasks/client.yml
+++ b/tasks/client.yml
@@ -27,7 +27,7 @@
   when: not ansible_check_mode and "CernVM-FS map is not referenced" in cvmfs_config_chksetup_out.stdout
 
 - name: Configure CernVM-FS config repository
-  when: (cvmfs_config_repo | bool) and cvmfs_config_repo_supported
+  when: (cvmfs_config_repo is truthy) and cvmfs_config_repo_supported
   block:
     - name: Create config repo config
       ansible.builtin.copy:
@@ -57,6 +57,12 @@
       ansible.builtin.file:
         path: /etc/cvmfs/domain.d/{{ cvmfs_config_repo.domain }}.conf
         state: absent
+
+- name: Remove config repository config
+  ansible.builtin.file:
+    path: /etc/cvmfs/default.d/80-ansible-galaxyproject-cvmfs.conf
+    state: absent
+  when: cvmfs_config_repo is not truthy
 
 - name: Configure CernVM-FS domain
   ansible.builtin.copy:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,23 +4,22 @@
 - name: Set OS-specific variables
   ansible.builtin.include_vars: "{{ ansible_os_family | lower }}.yml"
 
-- name: Set facts for Galaxy CVMFS config repository, if enabled
-  ansible.builtin.set_fact:
-    cvmfs_config_repo: "{{ galaxy_cvmfs_config_repo }}"
-  when: galaxy_cvmfs_repos_enabled and galaxy_cvmfs_repos_enabled == 'config-repo'
+- name: Fail on usage of deprecated Galaxy config repo
+  ansible.builtin.assert:
+    that: (not galaxy_cvmfs_repos_enabled) or (galaxy_cvmfs_repos_enabled != 'config-repo')
+    fail_msg: "'galaxy_cvmfs_repos_enabled: config-repo' is no longer supported, set to 'true' instead"
 
-- name: Set facts for Galaxy CVMFS static repositories, if enabled
+- name: Set facts for Galaxy CVMFS repositories, if enabled
   ansible.builtin.set_fact:
     cvmfs_keys: "{{ cvmfs_keys + galaxy_cvmfs_keys }}"
     cvmfs_repositories: "{{ cvmfs_repositories + galaxy_cvmfs_repositories }}"
     cvmfs_server_urls: "{{ cvmfs_server_urls + galaxy_cvmfs_server_urls }}"
-  when: galaxy_cvmfs_repos_enabled and galaxy_cvmfs_repos_enabled != 'config-repo'
+  when: galaxy_cvmfs_repos_enabled
 
 - name: Set facts for CVMFS config repository, if enabled
   ansible.builtin.set_fact:
     cvmfs_keys: "{{ cvmfs_keys + [cvmfs_config_repo.key] }}"
-  # In Ansible >= 2.10 this will be | truthy
-  when: cvmfs_config_repo | length > 0
+  when: cvmfs_config_repo is truthy
 
 - name: Include Client Tasks
   ansible.builtin.include_tasks: client.yml

--- a/tasks/stratum1.yml
+++ b/tasks/stratum1.yml
@@ -57,7 +57,7 @@
   ansible.builtin.command: >-
     /usr/bin/cvmfs_server add-replica -o {{ item.owner | default('root') }}
       http://{{ item.stratum0 }}/cvmfs/{{ item.repository }}
-      {{ item.key_dir | default('/etc/cvmfs/keys') }}/{{ item.repository }}.pub
+      {{ item.key_dir | default('/etc/cvmfs/keys') }}/{{ item.key_name | default(item.repository) }}.pub
   args:
     creates: /etc/cvmfs/repositories.d/{{ item.repository }}
   loop: "{{ cvmfs_repositories }}"


### PR DESCRIPTION
Per [the docs](https://cvmfs.readthedocs.io/en/stable/cpt-configure.html#the-config-repository), config repos are really for site usage, not for repo providers:

> The config repository is a very convenient method for updating the configuration on a lot of CernVM-FS clients at once. This also means that it is very easy to break configurations on a lot of clients at once. Also note that only one config repository may be used per client, and this is a technical limitation that is not expected to change. For these reasons, it makes the most sense to reserve the use of this feature for large groups of sites that share a common infrastructure with trusted people that maintain the configuration repository. In order to facilitate sharing of configurations between the infrastructures, a [github repository](https://github.com/cvmfs-contrib/config-repo) has been set up. Infrastructure maintainers are invited to collaborate there.