### PR TITLE
Support installing alternative cvmfs-config packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,12 @@ variable | type | description
 `cvmfs_srv_mount` | path | Path to mount CVMFS data volume on. Default is `/srv` (but is ignored if `cvmfs_srv_device` is unset).
 `cvmfs_union_fs` | string | Union filesystem type (`overlayfs` or `aufs`) for new repositories on Stratum 0 servers.
 `cvmfs_numfiles` | integer | Set the maximum number of open files in `/etc/security/limits.conf`. Useful with the `CVMFS_NFILES` client option on Stratum 0 servers.
+`cvmfs_config_packaage` | string | Optional package providing `config-config`, see below.
+
+The `cvmfs_config_package` can be set to a URL or package name to install (via `apt` or `dnf`) to preconfigure CVMFS as
+discussed in [the documentation][cvmfs-config-repo]. Alternatively, these can be set to the URL of the appropriate
+[`cvmfs-config-none`](https://ecsft.cern.ch/dist/cvmfs/cvmfs-config/) package to prevent any preconfiguration. If unset,
+the CVMFS client package installs `cvmfs-config-default`, which provides a default config for the cern.ch domain.
 
 [defaults]: https://github.com/galaxyproject/ansible-cvmfs/blob/master/defaults/main.yml
 [cvmfs-config-repo]: https://cvmfs.readthedocs.io/en/stable/cpt-configure.html#the-config-repository

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,6 +10,10 @@ cvmfs_http_proxies:
 cvmfs_quota_limit: 4000
 cvmfs_cache_base: "/var/lib/cvmfs"
 
+# If set, installs a package that satisfies cvmfs-config prior to installing CVMFS itself, for distributing config via
+# package
+cvmfs_config_package: null
+
 cvmfs_manage_firewall: false
 
 cvmfs_stratum0_http_ports:

--- a/tasks/client.yml
+++ b/tasks/client.yml
@@ -58,6 +58,14 @@
         path: /etc/cvmfs/domain.d/{{ cvmfs_config_repo.domain }}.conf
         state: absent
 
+- name: Ensure domain directory exists
+  ansible.builtin.file:
+    path: /etc/cvmfs/domain.d
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+
 - name: Configure CernVM-FS domain
   ansible.builtin.copy:
     content: |
@@ -68,7 +76,7 @@
     dest: /etc/cvmfs/domain.d/{{ item.domain }}.conf
     owner: root
     group: root
-    mode: 0444
+    mode: "0644"
   with_items: "{{ cvmfs_server_urls }}"
 
 - name: Configure CernVM-FS global client settings
@@ -77,7 +85,7 @@
     dest: /etc/cvmfs/default.local
     owner: root
     group: root
-    mode: 0644
+    mode: "0644"
 
 - name: Include repository client options tasks
   ansible.builtin.include_tasks: options.yml

--- a/tasks/init_debian.yml
+++ b/tasks/init_debian.yml
@@ -44,6 +44,12 @@
     update_cache: yes
   when: __cvmfs_apt_respository_result is changed
 
+- name: Install optional cvmfs-config package
+  ansible.builtin.apt:
+    name: "{{ ('://' in cvmfs_config_package) | ternary(omit, cvmfs_config_package) }}"
+    deb: "{{ ('://' in cvmfs_config_package) | ternary(cvmfs_config_package, omit) }}"
+  when: cvmfs_config_package is not none
+
 - name: Install CernVM-FS packages and dependencies (apt)
   ansible.builtin.apt:
     name: "{{ cvmfs_packages[_cvmfs_role] }}"

--- a/tasks/init_redhat.yml
+++ b/tasks/init_redhat.yml
@@ -64,7 +64,13 @@
     group: root
     mode: "0644"
 
-- name: Install CernVM-FS packages and dependencies (yum)
-  ansible.builtin.yum:
+- name: Install optional cvmfs-config package
+  ansible.builtin.dnf:
+    name: "{{ cvmfs_config_package }}"
+    disable_gpg_check: "{{ cvmfs_config_package_disable_gpg_check | default(omit) }}"
+  when: cvmfs_config_package is not none
+
+- name: Install CernVM-FS packages and dependencies (dnf)
+  ansible.builtin.dnf:
     name: "{{ cvmfs_packages[_cvmfs_role] }}"
     state: "{{ 'latest' if _cvmfs_upgrade else 'present' }}"

--- a/vars/debian.yml
+++ b/vars/debian.yml
@@ -11,11 +11,11 @@ cvmfs_packages:
   stratum0:
     - apache2
     - cvmfs-server
-    - cvmfs-config-default
   stratum1:
     - apache2
+    - libapache2-mod-wsgi-py3
     - cvmfs-server
-    - cvmfs-config-default
+    - squid
   localproxy:
     - squid
   client:

--- a/vars/redhat.yml
+++ b/vars/redhat.yml
@@ -11,14 +11,12 @@ cvmfs_packages:
   stratum0:
     - httpd
     - cvmfs-server
-    - cvmfs-config-default
     - cvmfs
   stratum1:
     - httpd
     - "{{ 'mod_wsgi' if ansible_distribution_major_version is version('8', '<') else 'python3-mod_wsgi' }}"
     - squid
     - cvmfs-server
-    - cvmfs-config-default
   localproxy:
     - squid
   client:


### PR DESCRIPTION
In particular `cvmfs-config-none` is nice for Galaxy because it avoids the default cern.ch configs. Those are unfortunately not part of any apt or yum repo that I'm aware of so you do have to install them directly via package URL.